### PR TITLE
fix corountine

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -294,11 +294,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722630065,
-        "narHash": "sha256-QfM/9BMRkCmgWzrPDK+KbgJOUlSJnfX4OvsUupEUZvA=",
+        "lastModified": 1722936497,
+        "narHash": "sha256-UBst8PkhY0kqTgdKiR8MtTBt4c1XmjJoOV11efjsC/o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "afc892db74d65042031a093adb6010c4c3378422",
+        "rev": "a6c743980e23f4cef6c2a377f9ffab506568413a",
         "type": "github"
       },
       "original": {
@@ -463,11 +463,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722907736,
-        "narHash": "sha256-drU5kbx9EtTqg7rXc6ni0LZuZQy7l/wVgsQ8PSYl5Qw=",
+        "lastModified": 1722994187,
+        "narHash": "sha256-K5V2N5HkGaLpf5StNbtKBM6O9K+CYF/8F8hlGUVgiKk=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "b3c49142939ba6072cb8bdd6109e36d1b70a055a",
+        "rev": "6fc50b0716bc415cfd1bc81bb9e198d78cd03b3d",
         "type": "github"
       },
       "original": {
@@ -579,11 +579,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1722936537,
-        "narHash": "sha256-Ux0Ko4h7mSTbU4y7t5d7bovxtpJ+iByEomDvAPg/JUQ=",
+        "lastModified": 1723010397,
+        "narHash": "sha256-VWg48uh3mcHSd+2N1sDS5Dz+kagKbs6ZQsj6PDaWT5k=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4f0cf621f5753d763dfac977f150c98ed9ed202e",
+        "rev": "91eb7c0364e6e1dd90c3c1feda6ee9793794461b",
         "type": "github"
       },
       "original": {

--- a/stow-managed/config/.config/Code/User/settings.json
+++ b/stow-managed/config/.config/Code/User/settings.json
@@ -76,6 +76,9 @@
     "editor.formatOnSave": true,
     "notebook.formatOnSave.enabled": true,
     "files.autoSave": "afterDelay",
+    "files.associations": {
+        "*.json": "jsonc"
+    },
     "github.copilot.editor.enableAutoCompletions": true,
     "cmake.options.statusBarVisibility": "visible",
     "nix.formatterPath": "nixfmt",
@@ -86,4 +89,5 @@
         "workbench.action.tasks.configureTaskRunner",
         "workbench.action.tasks.runTask"
     ],
+    "cmake.showConfigureWithDebuggerNotification": false,
 }


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance editor settings by adding file association for JSON files to be treated as JSONC and disable the CMake configure with debugger notification.

Enhancements:
- Add file association for JSON files to be treated as JSONC in the editor settings.

<!-- Generated by sourcery-ai[bot]: end summary -->