### PR TITLE
feat: update stateVersion to 26.05 and enhance host/home configurations

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773000227,
-        "narHash": "sha256-zm3ftUQw0MPumYi91HovoGhgyZBlM4o3Zy0LhPNwzXE=",
+        "lastModified": 1775037210,
+        "narHash": "sha256-KM2WYj6EA7M/FVZVCl3rqWY+TFV5QzSyyGE2gQxeODU=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "da529ac9e46f25ed5616fd634079a5f3c579135f",
+        "rev": "06648f4902343228ce2de79f291dd5a58ee12146",
         "type": "github"
       },
       "original": {
@@ -281,29 +281,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1772408722,
-        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-pparts": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_2"
-      },
-      "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -360,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774647770,
-        "narHash": "sha256-UNNi14XiqRWWjO8ykbFwA5wRwx7EscsC+GItOVpuGjc=",
+        "lastModified": 1775457580,
+        "narHash": "sha256-ikws/ssAmG20AGrEwBuwspwPlkubJu34mB+Uz2fJBJs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "02371c05a04a2876cf92e2d67a259e8f87399068",
+        "rev": "5de7dbd151b0bd65d45785553d4a22d832733ffc",
         "type": "github"
       },
       "original": {
@@ -416,11 +398,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1774553602,
-        "narHash": "sha256-BWM5X4JYmHJm3zoS9MFaxjPsDdR1sUs46O3ySiRNGy4=",
+        "lastModified": 1775510693,
+        "narHash": "sha256-gZfJ07j/oOciDi8mF/V8QTm7YCeDcusNSMZzBFi8OUM=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "6afcbf17d051e244cdaf371bca0aa33c85e8cf0e",
+        "rev": "3fe0ae8cb285e0ad101a9675f4190d455fb05e85",
         "type": "github"
       },
       "original": {
@@ -468,11 +450,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1774623710,
-        "narHash": "sha256-UVVA1OCUeDm7fnH98G+Okfb6vUuA1in89LZGDgVWR/4=",
+        "lastModified": 1775486894,
+        "narHash": "sha256-JPl4+i8DuzCtvyd5lsvO1HudGBF5OXlkNyJJ0GbB6uw=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "4814adf48100a2138b02591e6a7e000c106887b1",
+        "rev": "1d2eae174c96e2ba8504813e3a5b5fa93964a768",
         "type": "github"
       },
       "original": {
@@ -533,11 +515,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773561580,
-        "narHash": "sha256-wT0bKTp45YnMkc4yXQvk943Zz/rksYiIjEXGdWzxnic=",
+        "lastModified": 1774239543,
+        "narHash": "sha256-ZZ7V6xN0ATIHibLyaDBhmUGOqLqQzxuTx1ekOGCvLHI=",
         "owner": "openclaw",
         "repo": "nix-steipete-tools",
-        "rev": "cd4c429ff3b3aaef9f92e59812cf2baf5704b86f",
+        "rev": "5f677a283da837cad26c1ce982d85ee181085fc6",
         "type": "github"
       },
       "original": {
@@ -556,11 +538,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773727286,
-        "narHash": "sha256-n7gZKq9pJb0IoRsAPxZqjYWbm8/v2UdrZxARlmlKzvk=",
+        "lastModified": 1774824790,
+        "narHash": "sha256-3R2aoykbutdJ7YQaZiU7uO8w4O8b6RjztTPNo8isLTI=",
         "owner": "oddlama",
         "repo": "nix-topology",
-        "rev": "49b439d8749703989a42f28a4bfe198b2b315894",
+        "rev": "5765ce41be8a4fb5471a57671c2b740a350c5da0",
         "type": "github"
       },
       "original": {
@@ -571,11 +553,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1774567711,
-        "narHash": "sha256-uVlOHBvt6Vc/iYNJXLPa4c3cLXwMllOCVfAaLAcphIo=",
+        "lastModified": 1775490113,
+        "narHash": "sha256-2ZBhDNZZwYkRmefK5XLOusCJHnoeKkoN95hoSGgMxWM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3f6f874dfc34d386d10e434c48ad966c4832243e",
+        "rev": "c775c2772ba56e906cbeb4e0b2db19079ef11ff7",
         "type": "github"
       },
       "original": {
@@ -595,11 +577,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773882647,
-        "narHash": "sha256-VzcOcE0LLpEnyoxLuMuptZ9ZWCkSBn99bTgEQoz5Viw=",
+        "lastModified": 1774972752,
+        "narHash": "sha256-DnLIpFxznohpLkIFs390uZ0gxwkVyhtknhKNu+lQJK8=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "fd0eae98d1ecee31024271f8d64676250a386ee7",
+        "rev": "d97e078f4788cddb8d11c3c99f72a4bb9ddec221",
         "type": "github"
       },
       "original": {
@@ -611,11 +593,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774386573,
-        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "lastModified": 1775423009,
+        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
         "type": "github"
       },
       "original": {
@@ -627,26 +609,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1772328832,
-        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib_2": {
-      "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
         "type": "github"
       },
       "original": {
@@ -657,11 +624,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1774664579,
-        "narHash": "sha256-x625KqlfEGXJy+vGFtLWIyCpH7QqWeOn3HNRqtu07i4=",
+        "lastModified": 1775528787,
+        "narHash": "sha256-Ar1Y6AoM8lT+JT76g+C5IXVgrhXpFOpg4yMdDyvHU+A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1ba28435d06ab6b06e8f8fe191adacbb091d0a1f",
+        "rev": "b1fffc96c6cdff8537861af4cca96946c59536de",
         "type": "github"
       },
       "original": {
@@ -697,11 +664,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774663769,
-        "narHash": "sha256-V87AOCWjDMDC4NZQj5OVWnbVED8nZUDuhHdB/brdRSQ=",
+        "lastModified": 1775528938,
+        "narHash": "sha256-BcbKImQ79yCSytXovoOWaeyxmCyvFHaUD6c4KQ9tJZ0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e5d67d816153fcbb69bad856d3c444edc4d68ff3",
+        "rev": "4ceaa0b5f428c8014d49982b46e45bd9d70e0c3e",
         "type": "github"
       },
       "original": {
@@ -724,11 +691,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773851886,
-        "narHash": "sha256-+3ygZuf5K8mtSGMMEZ/h+vxGvXCu1CmiB+531KMagH8=",
+        "lastModified": 1775328099,
+        "narHash": "sha256-Cibc8aRJrWGuLrkDdcTGpx73gT93Fe8vfs35M1y2HH4=",
         "owner": "openclaw",
         "repo": "nix-openclaw",
-        "rev": "64d410666821866c565e048a4d07d6cf5d8e494e",
+        "rev": "0f4d0666f1490cbe1ba76062275eb22d2f89cc44",
         "type": "github"
       },
       "original": {
@@ -763,11 +730,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774104215,
-        "narHash": "sha256-EAtviqz0sEAxdHS4crqu7JGR5oI3BwaqG0mw7CmXkO8=",
+        "lastModified": 1775036584,
+        "narHash": "sha256-zW0lyy7ZNNT/x8JhzFHBsP2IPx7ATZIPai4FJj12BgU=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "f799ae951fde0627157f40aec28dec27b22076d0",
+        "rev": "4e0eb042b67d863b1b34b3f64d52ceb9cd926735",
         "type": "github"
       },
       "original": {
@@ -859,11 +826,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773909723,
-        "narHash": "sha256-HmcZQ/hMPHR22Ri/6Sl7Z0B5J8nZa9bRnZJtDFInM7I=",
+        "lastModified": 1774498001,
+        "narHash": "sha256-wTfdyzzrmpuqt4TQQNqilF91v0m5Mh1stNy9h7a/WK4=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "d37dcf34ac7194eac4b0d10520d01298c434267d",
+        "rev": "794afa6eb588b498344f2eaa36ab1ceb7e6b0b09",
         "type": "github"
       },
       "original": {
@@ -932,21 +899,21 @@
         "flake-parts": [
           "flake-parts"
         ],
-        "flake-pparts": "flake-pparts",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773806354,
-        "narHash": "sha256-VwY8R74p4MO55Vuj5KOciqeVOhKQHK448XG5kgBBr1Y=",
-        "ref": "refs/heads/main",
-        "rev": "eda0e61e1d6cd8f757dc985516aba098495294f0",
-        "revCount": 119,
+        "lastModified": 1775481351,
+        "narHash": "sha256-iFOIs8ni2UuO2f2Z1YsNAQ4CfuSmKxFKVh+b9LGxoPY=",
+        "ref": "feat/nixos-improvements",
+        "rev": "8d31a51b6fccc165d0aa820b4cd57d171c2ef32b",
+        "revCount": 120,
         "type": "git",
         "url": "ssh://git@github.com/AutoLifeRobot/rust-web-server.git"
       },
       "original": {
+        "ref": "feat/nixos-improvements",
         "type": "git",
         "url": "ssh://git@github.com/AutoLifeRobot/rust-web-server.git"
       }
@@ -981,11 +948,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774303811,
-        "narHash": "sha256-fhG4JAcLgjKwt+XHbjs8brpWnyKUfU4LikLm3s0Q/ic=",
+        "lastModified": 1775365543,
+        "narHash": "sha256-f50qrK0WwZ9z5EdaMGWOTtALgSF7yb7XwuE7LjCuDmw=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "614e256310e0a4f8a9ccae3fa80c11844fba7042",
+        "rev": "a4ee2de76efb759fe8d4868c33dec9937897916f",
         "type": "github"
       },
       "original": {
@@ -1001,11 +968,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774517972,
-        "narHash": "sha256-oPIVzGlMmfWuJlRbr87yU3cnV8NxtwTG92GqpQczlkw=",
+        "lastModified": 1775444042,
+        "narHash": "sha256-cg19ipIlZaLYgs/5ZPFcDDuOcZlGzfprB5xS4x7bVM4=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "0ddba2fbd72bb60f8b35b7de1ad67590f454d402",
+        "rev": "64c9cc6a274dac7d08c4d53494ffa4acf906e287",
         "type": "github"
       },
       "original": {
@@ -1037,11 +1004,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773297127,
-        "narHash": "sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk=",
+        "lastModified": 1775125835,
+        "narHash": "sha256-2qYcPgzFhnQWchHo0SlqLHrXpux5i6ay6UHA+v2iH4U=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "71b125cd05fbfd78cab3e070b73544abe24c5016",
+        "rev": "75925962939880974e3ab417879daffcba36c4a3",
         "type": "github"
       },
       "original": {
@@ -1062,11 +1029,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774315256,
-        "narHash": "sha256-jhlzSXk0Rv4cSHoRgEecEcv+veN0q3sD3PIAgqgpwcI=",
+        "lastModified": 1774490495,
+        "narHash": "sha256-a9WmQWj8fF7BctZGCoyzpUjP6GJw8H+lxl+zxpGnETk=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "0623db9a65da877e4f6f67ed946ffd65401720f0",
+        "rev": "18ae62fc5e389e3069854a7c66455c22e31708fc",
         "type": "github"
       },
       "original": {
@@ -1114,11 +1081,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1774327885,
-        "narHash": "sha256-5xlUJ+sDoWrvDht/FxDD3zblCwdxntuthCRjh5TU8ls=",
+        "lastModified": 1775471732,
+        "narHash": "sha256-XeoPvJXn2aIOusNeR+k1m3M2XP+77HuzFlyWS/lp3O0=",
         "owner": "xiongchenyu6",
         "repo": "nur-packages",
-        "rev": "17db97051c93c5648cb2c97cac8d124db4ed92e2",
+        "rev": "51e6b00434769903fd8ee7e6c05068d2f71e6cdc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -112,7 +112,7 @@
       };
     };
     rust-web-server = {
-      url = "git+ssh://git@github.com/AutoLifeRobot/rust-web-server.git";
+      url = "git+ssh://git@github.com/AutoLifeRobot/rust-web-server.git?ref=feat/nixos-improvements";
       #url = "git+ssh://git@github.com/AutoLifeRobot/rust-web-server.git?shallow=1&rev=0ff6f6d5dbd1131b34bec7c8316eb8ee21713e73";
       inputs = {
         nixpkgs.follows = "nixpkgs";

--- a/home-configurations/root.nix
+++ b/home-configurations/root.nix
@@ -4,7 +4,7 @@
 
   home = {
     username = "root";
-    stateVersion = "25.05";
+    stateVersion = "26.05";
     homeDirectory = osConfig.users.users.root.home;
   };
 }

--- a/home-modules/cli-minimal.nix
+++ b/home-modules/cli-minimal.nix
@@ -342,7 +342,7 @@ in
         '';
       };
     };
-    stateVersion = "25.05";
+    stateVersion = "26.05";
     keyboard = {
       options = [ "caps:ctrl_modifier" ];
     };

--- a/home-modules/gui/packages.nix
+++ b/home-modules/gui/packages.nix
@@ -12,9 +12,9 @@
       with pkgs;
       [
         #appimage-run
-        inputs.llm-agents.packages.${pkgs.system}.mcporter
-        # inputs.llm-agents.packages.${pkgs.system}.cc-switch-cli # temporarily disabled: hash mismatch upstream
-        inputs.llm-agents.packages.${pkgs.system}.auto-claude
+        inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.mcporter
+        # inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.cc-switch-cli # temporarily disabled: hash mismatch upstream
+        inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.auto-claude
         discord
         telegram-desktop
         cloc

--- a/home-modules/neovim.nix
+++ b/home-modules/neovim.nix
@@ -1759,8 +1759,8 @@ in
         ]
         ++ lib.optionals (!cfg.lightweight) [
           # Language servers (desktop only)
-          nodePackages.typescript-language-server
-          nodePackages.vscode-langservers-extracted
+          typescript-language-server
+          vscode-langservers-extracted
           pyright
           gopls
           rust-analyzer # Rust LSP (used by rustaceanvim)
@@ -1773,7 +1773,7 @@ in
           solc # Solidity compiler
 
           # Formatters and linters (desktop only)
-          nodePackages.prettier
+          prettier
           black
           rustfmt
 

--- a/home-modules/use-remote-builder.nix
+++ b/home-modules/use-remote-builder.nix
@@ -4,7 +4,7 @@
 { lib, ... }:
 {
   home = {
-    stateVersion = "24.11";
+    stateVersion = "26.05";
   };
   programs = {
     ssh = {

--- a/nixos-configurations/game/default.nix
+++ b/nixos-configurations/game/default.nix
@@ -62,7 +62,7 @@
     systemPackages = with pkgs; [
       cloudflare-warp
       android-tools # Replaces programs.adb
-      inputs.lazynixos.packages.${pkgs.system}.default
+      inputs.lazynixos.packages.${pkgs.stdenv.hostPlatform.system}.default
     ];
   };
 

--- a/nixos-configurations/oracle-arm-001/default.nix
+++ b/nixos-configurations/oracle-arm-001/default.nix
@@ -25,6 +25,8 @@
     srvos.nixosModules.mixins-trusted-nix-caches
     srvos.nixosModules.mixins-nix-experimental
     srvos.nixosModules.mixins-tracing
+    inputs.rust-web-server.nixosModules.rust-web-server
+    ../../nixos-modules/rust-web-server-config.nix
     ./disk-config.nix
     ./hardware-configuration.nix
   ];
@@ -240,6 +242,12 @@
       };
     };
 
+    # Rust web server
+    rust-web-server = {
+      enable = true;
+      configFile = config.sops.templates."rust-web-server-config".path;
+    };
+
     nginx = {
       commonHttpConfig = ''
         map $http_origin $cors_origin {
@@ -362,6 +370,9 @@
 
   nixpkgs = {
     hostPlatform = "aarch64-linux";
+    config.permittedInsecurePackages = [
+      "python3.12-pypdf2-3.0.1"
+    ];
     # overlays = [
     #   (final: prev: {
     #     odoo = prev.odoo.overrideAttrs (old: {

--- a/nixos-configurations/oracle-arm-002/default.nix
+++ b/nixos-configurations/oracle-arm-002/default.nix
@@ -8,7 +8,7 @@
   ...
 }:
 let
-  mcporter = inputs.llm-agents.packages.${pkgs.system}.mcporter;
+  mcporter = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.mcporter;
 
   # Workaround: nix-openclaw copies source extensions/ and compiled dist/extensions/
   # separately, but plugin manifests (openclaw.plugin.json) only exist in extensions/.
@@ -113,7 +113,9 @@ in
   '';
 
   sops.templates."s3fs-passwd" = {
-    content = "${config.sops.placeholder."s3fs/access_key"}:${config.sops.placeholder."s3fs/secret_key"}";
+    content = "${config.sops.placeholder."s3fs/access_key"}:${
+      config.sops.placeholder."s3fs/secret_key"
+    }";
     mode = "0600";
     owner = "root";
     group = "root";
@@ -176,7 +178,6 @@ in
   networking.firewall.allowedTCPPorts = [
     6080
   ];
-
 
   services.openclaw-gateway = {
     enable = true;

--- a/nixos-modules/nas.nix
+++ b/nixos-modules/nas.nix
@@ -24,9 +24,9 @@
     aria2 = {
       enable = true;
       openPorts = true;
-      downloadDir = "/srv/media/downloads";
       rpcSecretFile = config.sops.secrets."aria2/rpc-secret".path;
       settings = {
+        dir = "/srv/media/downloads";
         enable-rpc = true;
         rpc-listen-all = true;
         rpc-allow-origin-all = true;

--- a/shared-modules/default.nix
+++ b/shared-modules/default.nix
@@ -5,6 +5,13 @@
   lib,
 }:
 let
+  masterPkgsFor =
+    system:
+    import inputs.nixpkgs-master {
+      inherit system;
+      config.allowUnfree = true;
+    };
+
   # Common overlays shared between Darwin and NixOS
   baseOverlays =
     with inputs;
@@ -39,6 +46,7 @@ in
           # telegram-desktop =
           #   nixpkgs-stable.legacyPackages.x86_64-linux.telegram-desktop;
           # waybar = nixpkgs-master.legacyPackages.x86_64-linux.waybar;
+          claude-code = (masterPkgsFor prev.stdenv.hostPlatform.system).claude-code;
           netbird = prev.netbird.override {
             buildGoModule = prev.buildGo125Module;
           };

--- a/stow-managed/config/.config/xmonad/flake.nix
+++ b/stow-managed/config/.config/xmonad/flake.nix
@@ -9,20 +9,27 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils, }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
         inherit (pkgs) haskellPackages;
         # DON'T FORGET TO PUT YOUR PACKAGE NAME HERE, REMOVING `throw`
         packageName = "my-xmonad";
-      in {
+      in
+      {
         packages.${packageName} =
-          haskellPackages.callCabal2nix (nixpkgs.lib.debug.traceVal packageName)
-          (builtins.toString ./.) {
-            # Dependency overrides go here
-          };
+          haskellPackages.callCabal2nix (nixpkgs.lib.debug.traceVal packageName) (builtins.toString ./.)
+            {
+              # Dependency overrides go here
+            };
 
         doUnpack = false;
 
@@ -33,14 +40,15 @@
             haskellPackages.haskell-language-server # you must build it with your ghc to work
             ghcid
             cabal-install
-            # xlibsWrapper
-            xorg.libXext
+            #             xlibsWrapper
+            libxext
             alsaLib.dev
-            xorg.libXrandr
-            xorg.libXScrnSaver
+            libxrandr
+            libxscrnsaver
           ];
           nativeBuildInputs = with pkgs; [ pkg-config ];
           inputsFrom = builtins.attrValues self.packages.${system};
         };
-      });
+      }
+    );
 }


### PR DESCRIPTION
Bump stateVersion to 26.05 in home-manager configurations, update rust-web-server to use feat/nixos-improvements branch, and add various packages (claude-code, lazynixos).

## Summary by Sourcery

Update NixOS and home-manager configurations to use newer state versions, improved package references, and integrate the rust-web-server module on specific hosts.

New Features:
- Enable and configure the rust-web-server module on the oracle-arm-001 host using a SOPS-managed config file.

Bug Fixes:
- Fix mcporter and related llm-agents package resolution by using pkgs.stdenv.hostPlatform.system instead of pkgs.system.
- Correct s3fs-passwd SOPS template interpolation for access and secret keys on oracle-arm-002.

Enhancements:
- Bump home-manager stateVersion values to 26.05 across relevant configurations.
- Adjust various package references to use pkgs.stdenv.hostPlatform.system for better platform correctness.
- Expose the claude-code package via nixpkgs-master in shared overlays.
- Switch the rust-web-server flake input to track the feat/nixos-improvements branch.
- Refine neovim language server and formatter package selections to use top-level packages instead of nodePackages where available.
- Simplify and modernize xmonad flake and build inputs, including X11 library dependencies and formatting tweaks.
- Set aria2 download directory via its settings attribute in the NAS module.
- Allow an insecure python3.12-pypdf2 package on oracle-arm-001 for compatibility needs.