### PR TITLE
feat: configure rust-web-server license, add cc-gateway, and improve openclaw packaging

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,35 @@
+## Stage 1: Add cc-gateway package and module
+**Goal**: Import the cc-gateway NixOS module and add the cc-gateway package to oracle-arm-002.
+**Success Criteria**: `oracle-arm-002` imports `inputs.xiongchenyu6.nixosModules.cc-gateway` and includes `inputs.xiongchenyu6.packages.aarch64-linux.cc-gateway` in `environment.systemPackages`.
+**Tests**: `nix flake check` or targeted host evaluation succeeds.
+**Status**: Complete
+
+## Stage 2: Configure SOPS-backed cc-gateway service
+**Goal**: Declare `cc-gateway` secrets and enable `services.cc-gateway` using those files.
+**Success Criteria**: Host config declares the needed SOPS secrets and a complete `services.cc-gateway` stanza.
+**Tests**: Nix evaluation resolves all `config.sops.secrets.*.path` references without assertion failures.
+**Status**: Complete
+
+## Stage 3: Add placeholder secrets to SOPS
+**Goal**: Add encrypted placeholder/random `cc-gateway` values to `secrets/common.yaml`.
+**Success Criteria**: `cc-gateway` keys exist in the encrypted secrets file and decrypt correctly.
+**Tests**: `sops -d secrets/common.yaml` shows the new keys.
+**Status**: Complete
+
+## Stage 4: Validate the host configuration
+**Goal**: Verify the updated oracle-arm-002 configuration evaluates cleanly.
+**Success Criteria**: Evaluation/build checks complete without config errors.
+**Tests**: `nix flake check`; if needed, `nixos-rebuild build --flake .#oracle-arm-002`.
+**Status**: Complete
+
+## Stage 5: Stabilize openclaw-gateway dependency fetch
+**Goal**: Add a host-local workaround for flaky `openclaw-gateway` pnpm dependency prefetching.
+**Success Criteria**: `oracle-arm-002` overrides the upstream `pnpmDeps` fetch with retry tuning while preserving the existing runtime/install patches.
+**Tests**: `nixos-rebuild build --flake .#oracle-arm-002` progresses past `openclaw-gateway-pnpm-deps`.
+**Status**: In Progress
+
+## Stage 6: Revalidate oracle-arm-002 build
+**Goal**: Rebuild the host after the OpenClaw workaround.
+**Success Criteria**: The previous `ECONNRESET` failure is gone or moved past the prior failing derivation.
+**Tests**: `nixos-rebuild build --flake .#oracle-arm-002`.
+**Status**: Not Started

--- a/flake.lock
+++ b/flake.lock
@@ -450,11 +450,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1775486894,
-        "narHash": "sha256-JPl4+i8DuzCtvyd5lsvO1HudGBF5OXlkNyJJ0GbB6uw=",
+        "lastModified": 1775532444,
+        "narHash": "sha256-3tDtwXFP3KXUUnnsh3HxnxBoZtUdAiaQLIJCGHQIYQI=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "1d2eae174c96e2ba8504813e3a5b5fa93964a768",
+        "rev": "14987a4f161451bfb2154e6a29c039bce636f8ad",
         "type": "github"
       },
       "original": {
@@ -624,11 +624,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1775528787,
-        "narHash": "sha256-Ar1Y6AoM8lT+JT76g+C5IXVgrhXpFOpg4yMdDyvHU+A=",
+        "lastModified": 1775531914,
+        "narHash": "sha256-hWArO+z1CMayl8VE9dWmUDI7Aa/SyAPnnE1p3dMXY/c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b1fffc96c6cdff8537861af4cca96946c59536de",
+        "rev": "44387ac2e7b116618ae4877d3bd478595657847e",
         "type": "github"
       },
       "original": {
@@ -664,11 +664,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775528938,
-        "narHash": "sha256-BcbKImQ79yCSytXovoOWaeyxmCyvFHaUD6c4KQ9tJZ0=",
+        "lastModified": 1775532560,
+        "narHash": "sha256-m8vGQ/tuwrGHynXZCBNGx/Q3bcHnxnLcA0P1LFK07II=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ceaa0b5f428c8014d49982b46e45bd9d70e0c3e",
+        "rev": "0cd76af8d028e6aa8d3e969ea4c54e9990975b2e",
         "type": "github"
       },
       "original": {
@@ -1081,11 +1081,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1775471732,
-        "narHash": "sha256-XeoPvJXn2aIOusNeR+k1m3M2XP+77HuzFlyWS/lp3O0=",
+        "lastModified": 1775532740,
+        "narHash": "sha256-9U98nkRklp3R47+8+9qoqUtgPB/TPMy6f/d+sAfz8Z0=",
         "owner": "xiongchenyu6",
         "repo": "nur-packages",
-        "rev": "51e6b00434769903fd8ee7e6c05068d2f71e6cdc",
+        "rev": "0cb7c785b3ca1148c45316d2cfd89fe964103833",
         "type": "github"
       },
       "original": {

--- a/nixos-configurations/oracle-amd-002/default.nix
+++ b/nixos-configurations/oracle-amd-002/default.nix
@@ -24,6 +24,7 @@
     srvos.nixosModules.mixins-trusted-nix-caches
     srvos.nixosModules.mixins-nix-experimental
     srvos.nixosModules.mixins-tracing
+    xiongchenyu6.nixosModules.cc-gateway
     ./hardware-configuration.nix
   ];
 
@@ -36,5 +37,88 @@
         UsePAM = true;
       };
     };
+  };
+
+  sops.templates."cc-gateway-config" = {
+    content = ''
+      {
+        "server": {
+          "port": 18443
+        },
+        "upstream": {
+          "url": "https://api.anthropic.com"
+        },
+        "identity": {
+          "device_id": "${config.sops.placeholder."cc-gateway/device_id"}",
+          "email": "${config.sops.placeholder."cc-gateway/email"}"
+        },
+        "oauth": {
+          "refresh_token": "${config.sops.placeholder."cc-gateway/refresh_token"}"
+        },
+        "auth": {
+          "tokens": ${config.sops.placeholder."cc-gateway/client_tokens"}
+        },
+        "env": {
+          "platform": "linux",
+          "platform_raw": "linux",
+          "arch": "x86_64",
+          "node_version": "v22.0.0",
+          "terminal": "xterm-256color",
+          "package_managers": "npm",
+          "runtimes": "node",
+          "is_running_with_bun": false,
+          "is_ci": false,
+          "is_claude_ai_auth": true,
+          "version": "2.1.81",
+          "version_base": "2.1.81",
+          "build_time": "2026-03-20T21:26:18Z",
+          "deployment_environment": "nixos",
+          "vcs": "git"
+        },
+        "prompt_env": {
+          "platform": "linux",
+          "shell": "bash",
+          "os_version": "NixOS",
+          "working_dir": "/var/lib/cc-gateway"
+        },
+        "process": {
+          "constrained_memory": 34359738368,
+          "rss_range": [300000000, 500000000],
+          "heap_total_range": [40000000, 80000000],
+          "heap_used_range": [100000000, 200000000]
+        },
+        "logging": {
+          "level": "info",
+          "audit": true
+        }
+      }
+    '';
+    owner = "cc-gateway";
+    group = "cc-gateway";
+    mode = "0400";
+  };
+
+  sops.secrets."cc-gateway/email".owner = "cc-gateway";
+  sops.secrets."cc-gateway/device_id".owner = "cc-gateway";
+  sops.secrets."cc-gateway/refresh_token".owner = "cc-gateway";
+  sops.secrets."cc-gateway/client_tokens".owner = "cc-gateway";
+
+  users.users.cc-gateway = {
+    isSystemUser = true;
+    group = "cc-gateway";
+    home = "/var/lib/cc-gateway";
+    createHome = true;
+  };
+  users.groups.cc-gateway = { };
+
+  environment.systemPackages = with pkgs; [
+    inputs.xiongchenyu6.packages.x86_64-linux.cc-gateway
+  ];
+
+  services.cc-gateway = {
+    enable = true;
+    port = 18443;
+    openFirewall = false;
+    configFile = config.sops.templates."cc-gateway-config".path;
   };
 }

--- a/nixos-configurations/oracle-arm-001/default.nix
+++ b/nixos-configurations/oracle-arm-001/default.nix
@@ -246,6 +246,8 @@
     rust-web-server = {
       enable = true;
       configFile = config.sops.templates."rust-web-server-config".path;
+      licenseFile = config.sops.templates."rust-web-server-license".path;
+      publicKey = builtins.readFile ./id_ed25519.pub;
     };
 
     nginx = {
@@ -383,6 +385,12 @@
   };
 
   # Sops secrets for autolife-relay
+  sops.templates."rust-web-server-license" = {
+    content = config.sops.placeholder."autolife-relay/license";
+    owner = "rust-web-server";
+    group = "rust-web-server";
+    mode = "0400";
+  };
   sops.secrets."autolife-relay/license" = {
     owner = "autolife-relay";
     group = "autolife-relay";

--- a/nixos-configurations/oracle-arm-002/default.nix
+++ b/nixos-configurations/oracle-arm-002/default.nix
@@ -14,53 +14,78 @@ let
   # separately, but plugin manifests (openclaw.plugin.json) only exist in extensions/.
   # The gateway looks for them in dist/extensions/. Patch the package to copy them over.
   openclawPkg = pkgs.openclaw-gateway;
-  patchedOpenclaw = openclawPkg.overrideAttrs (old: {
-    # check_no_broken_symlinks exits 1 with current nixpkgs; patch the install script.
-    # Also preserve Fix 1 (plugin manifests) and Fix 2 (runtime stub).
-    installPhase =
-      let
-        # Replace the entire check_no_broken_symlinks function with a no-op.
-        # The function uses `find | while` which exits non-zero with set -e on NixOS sandbox.
-        patchedScript = pkgs.runCommand "gateway-install-patched.sh" { } ''
-          ${pkgs.gnused}/bin/sed \
-            '/^check_no_broken_symlinks()/,/^}/c\check_no_broken_symlinks() { echo "(symlink check disabled)"; }' \
-            ${old.installPhase} > $out
-          chmod +x $out
-        '';
-      in
-      ''
-        source ${patchedScript}
-      ''
-      + ''
-        set +e  # Disable set -e inherited from sourced install script for our additions
+  resilientOpenclawDeps = pkgs.fetchPnpmDeps {
+    pname = "openclaw-gateway";
+    version = openclawPkg.version;
+    src = openclawPkg.src;
+    pnpm = pkgs.pnpm_10;
+    hash = openclawPkg.passthru.sourceInfo.pnpmDepsHash;
+    fetcherVersion = 3;
+    nativeBuildInputs = [ pkgs.git ];
+    prePnpmInstall = ''
+      pnpm config set fetch-retries 10
+      pnpm config set fetch-retry-factor 2
+      pnpm config set fetch-retry-maxtimeout 600000
+      pnpm config set network-concurrency 8
+    '';
+  };
 
-        # Fix 1: Copy plugin manifests and package.json to dist/extensions/
-        for d in $out/lib/openclaw/extensions/*/; do
-          [ -d "$d" ] || continue
-          name=$(basename "$d")
-          if [ -d "$out/lib/openclaw/dist/extensions/$name" ]; then
-            [ -f "$d/openclaw.plugin.json" ] && cp "$d/openclaw.plugin.json" "$out/lib/openclaw/dist/extensions/$name/"
-            if [ -f "$d/package.json" ]; then
-              ${pkgs.gnused}/bin/sed 's/\.ts"/\.js"/g' "$d/package.json" > "$out/lib/openclaw/dist/extensions/$name/package.json"
+  # Workaround: nix-openclaw copies source extensions/ and compiled dist/extensions/
+  # separately, but plugin manifests (openclaw.plugin.json) only exist in extensions/.
+  # The gateway looks for them in dist/extensions/. Patch the package to copy them over.
+  patchedOpenclaw = openclawPkg.overrideAttrs (
+    final: old: {
+      pnpmDeps = resilientOpenclawDeps;
+      env = (old.env or { }) // {
+        PNPM_DEPS = final.pnpmDeps;
+      };
+      # check_no_broken_symlinks exits 1 with current nixpkgs; patch the install script.
+      # Also preserve Fix 1 (plugin manifests) and Fix 2 (runtime stub).
+      installPhase =
+        let
+          # Replace the entire check_no_broken_symlinks function with a no-op.
+          # The function uses `find | while` which exits non-zero with set -e on NixOS sandbox.
+          patchedScript = pkgs.runCommand "gateway-install-patched.sh" { } ''
+            ${pkgs.gnused}/bin/sed \
+              '/^check_no_broken_symlinks()/,/^}/c\check_no_broken_symlinks() { echo "(symlink check disabled)"; }' \
+              ${old.installPhase} > $out
+            chmod +x $out
+          '';
+        in
+        ''
+          source ${patchedScript}
+        ''
+        + ''
+          set +e  # Disable set -e inherited from sourced install script for our additions
+
+          # Fix 1: Copy plugin manifests and package.json to dist/extensions/
+          for d in $out/lib/openclaw/extensions/*/; do
+            [ -d "$d" ] || continue
+            name=$(basename "$d")
+            if [ -d "$out/lib/openclaw/dist/extensions/$name" ]; then
+              [ -f "$d/openclaw.plugin.json" ] && cp "$d/openclaw.plugin.json" "$out/lib/openclaw/dist/extensions/$name/"
+              if [ -f "$d/package.json" ]; then
+                ${pkgs.gnused}/bin/sed 's/\.ts"/\.js"/g' "$d/package.json" > "$out/lib/openclaw/dist/extensions/$name/package.json"
+              fi
             fi
-          fi
-        done
+          done
 
-        # Fix 2: Create dist/plugins/runtime/index.js stub.
-        mkdir -p $out/lib/openclaw/dist/plugins/runtime
-        chunk=$(${pkgs.gnugrep}/bin/grep -rl 'createPluginRuntime as ' $out/lib/openclaw/dist/setup-surface-*.js 2>/dev/null | head -1)
-        if [ -n "$chunk" ]; then
-          alias=$(${pkgs.gnugrep}/bin/grep -oP 'createPluginRuntime as \K\w+' "$chunk" | head -1)
-          chunkName=$(basename "$chunk")
-          echo ">> Creating plugin runtime stub: $chunkName alias=$alias"
-          printf 'import { %s as createPluginRuntime } from "../../%s";\nexport { createPluginRuntime };\n' \
-            "$alias" "$chunkName" \
-            > $out/lib/openclaw/dist/plugins/runtime/index.js
-        else
-          echo "WARNING: Could not find createPluginRuntime export in any setup-surface chunk"
-        fi
-      '';
-  });
+          # Fix 2: Create dist/plugins/runtime/index.js stub.
+          mkdir -p $out/lib/openclaw/dist/plugins/runtime
+          chunk=$(${pkgs.gnugrep}/bin/grep -rl 'createPluginRuntime as ' $out/lib/openclaw/dist/setup-surface-*.js 2>/dev/null | head -1)
+          if [ -n "$chunk" ]; then
+            alias=$(${pkgs.gnugrep}/bin/grep -oP 'createPluginRuntime as \K\w+' "$chunk" | head -1)
+            chunkName=$(basename "$chunk")
+            echo ">> Creating plugin runtime stub: $chunkName alias=$alias"
+            printf 'import { %s as createPluginRuntime } from "../../%s";\nexport { createPluginRuntime };\n' \
+              "$alias" "$chunkName" \
+              > $out/lib/openclaw/dist/plugins/runtime/index.js
+          else
+            echo "WARNING: Could not find createPluginRuntime export in any setup-surface chunk"
+          fi
+        '';
+    }
+  );
 
   # Shared packages available to both system environment and openclaw service
   sharedToolPkgs = with pkgs; [

--- a/nixos-configurations/oracle-arm-002/default.nix
+++ b/nixos-configurations/oracle-arm-002/default.nix
@@ -33,14 +33,12 @@ let
   # Workaround: nix-openclaw copies source extensions/ and compiled dist/extensions/
   # separately, but plugin manifests (openclaw.plugin.json) only exist in extensions/.
   # The gateway looks for them in dist/extensions/. Patch the package to copy them over.
-  patchedOpenclaw = openclawPkg.overrideAttrs (
-    final: old: {
-      pnpmDeps = resilientOpenclawDeps;
-      env = (old.env or { }) // {
-        PNPM_DEPS = final.pnpmDeps;
-      };
-      # check_no_broken_symlinks exits 1 with current nixpkgs; patch the install script.
-      # Also preserve Fix 1 (plugin manifests) and Fix 2 (runtime stub).
+  patchedOpenclaw = openclawPkg.overrideAttrs (old: {
+    pnpmDeps = resilientOpenclawDeps;
+    env = (old.env or { }) // {
+      PNPM_DEPS = resilientOpenclawDeps;
+    };
+    # check_no_broken_symlinks exits 1 with current nixpkgs; patch the install script.      # Also preserve Fix 1 (plugin manifests) and Fix 2 (runtime stub).
       installPhase =
         let
           # Replace the entire check_no_broken_symlinks function with a no-op.
@@ -84,8 +82,7 @@ let
             echo "WARNING: Could not find createPluginRuntime export in any setup-surface chunk"
           fi
         '';
-    }
-  );
+  });
 
   # Shared packages available to both system environment and openclaw service
   sharedToolPkgs = with pkgs; [

--- a/nixos-modules/rust-web-server-config.nix
+++ b/nixos-modules/rust-web-server-config.nix
@@ -46,12 +46,17 @@ in
           introspection_endpoint: ${shares.oauth.introspection_endpoint}
         auth:
           enabled: true
+        ${
+          lib.optionalString (cfg.licenseFile != null && cfg.publicKey != null) ''
+            auth_license:
+              license_file: ${cfg.licenseFile}
+              public_key: ${cfg.publicKey}
+          ''
+        }
       '';
-      mode = "0600";
-      # The owner and group will be created by the upstream rust-web-server module
-      # For now, use root to avoid dependency issues
-      owner = "root";
-      group = "root";
+      mode = "0400";
+      owner = "rust-web-server";
+      group = "rust-web-server";
     };
 
     # User and systemd service are defined by the upstream rust-web-server module

--- a/secrets/common.yaml
+++ b/secrets/common.yaml
@@ -1,214 +1,219 @@
 postgrest:
-    pass: ENC[AES256_GCM,data:ztHEPVHzokmSbU2g4lDuBe72b2TfZQ==,iv:bwOqEGAbSG7Lm84IiTcQAjiihsOlJ+F+h0OQQGzkH7E=,tag:hoBK84hA6TohQ1fUr+2ESw==,type:str]
-    jwt-secret: ENC[AES256_GCM,data:8BjZTNPqeh221srf/036toIeVAHhbwJaSmJtxODmF/67rYfYZZQxP8/ky8YBdnigfhvAQZaMKESBK5phDvsiOcI1WktZKnYKe0fWZ2mhQowKsxqRtZ29O0gXhuUZ2XeeVKhOepf90GpQlEOJao6CXg8lnVU4uZJpJRTfK5LvTqQR4l4qLlWvxB/vxkmtFmU1sHpLhWtaw//A/xfhVm0ApoDgL3EJ3yq5BrcrqlswfLgtSBT55EQFOJJtwg8mhuI7ANLtW4T2Uk2K0dF6bc5XW+WDUDUpZqtz1le0kodUWoUCXm8BrFXzRsy4tpm1e4Y14s1VzBZLuYka/PpB8XwckzfV1Zk+5XFRIiFym7BTIk3dORtD1TU8OcBR+LaMWrf5yGMR0yMrhccLUafup9i+3S6J3KegrDlkklDXqYlPrIOToa7zrgENvisDKr3qI7XTiZuf2iO0Nmjgmf/fdySCQ7ekDhuEurH20d5L/aJ65ATMHZ/zbmNZkOK8CdaTf4pocfXErT/LOONbCP4ibqPZ53Jr5H+4GubQsPXMR1k4lJSy7rfAA00YdmyJKZ+Q8Vw=,iv:fYn45kpkd97Zt6+Dg8z09+1aeEzRxeoLjXTETnSX+J8=,tag:fPw/s2Yjta794K7MWfcL/g==,type:str]
-nixAccessTokens: ENC[AES256_GCM,data:OrNHXKNr0A79Vxw1a8WmAf8bkll+mUl9tFlZfZH+/ocWXIpJyW8eZgcZJw5r8OJS5Rl5+YdjtKADpOaKEX6AphCwWVk=,iv:KsGCK2Pn8QBhCze561PwN2V3bNehdAhX2JZGzB1K7h4=,tag:YMLTeHqV4O1HbRaEQbePAw==,type:str]
+    pass: ENC[AES256_GCM,data:MnCTzoj+ZudchJ6bDB43X7zFQ8duuA==,iv:DRQUIT56vUTMUobUzTpCM6MMZG1FNwRIxrvs6iL1Ksw=,tag:O+vvQk3/+tiiaI7Ifj2Qpw==,type:str]
+    jwt-secret: ENC[AES256_GCM,data:rZCZtzcRVwHke0YAZfsguFHPFG79suweWBoG9Os0ZxsoMeCiiOwBnwN1+Q7jOD7NgVX6bwaaaAb5bPve52GCvMRRTWIB0nNnYdQAW5+aQBLjoeEw77lP1I0DaTe+dvTsgbuZ8U2DgvqFa0D+n6/wKuo+fQ3XpPZjw+xuG9LijuTZHqvkzFa5+P/oKyJdoqWEyxmNufVonN//6M2lSODJ7DGsKDulBvtF3pKMittqHgCEFoB+7iK5Ft3hxd5PlYbqALgTcYysIQsQ7T2s6qbRk//WhG0LC25HVetYnKpachaEeJdQwRffKjMTMRxKGBMDsuOqRxzOQ93ln6v4hcKCo3RYQJ9CFtwC++emluV1GpvhC9iFZlOgh8EDCTjxGBdT1R+BxOGdfHFenoyu9y+zxHmL3TeO1ZIZurZhSc9HOsj3ir8KEjPmscd4+2Y/vxF5FN7if7caGubR4RqJJoSKrftly5Jvn/hSNeoGVAzBcuP11/Z8oMobVRy9B10e4Zz5MQmI+OLxASI+wHv/gAZxmjA0gQju+4TmRrchomjEyCGZ3AqEt2A4ZvybRITEpVo=,iv:omUXXjIUxIAXf+l4/djRJzuCTrICXPJ3xc2w4b930UM=,tag:CMHK7CjtJ8Gkh+ped7hlfQ==,type:str]
+nixAccessTokens: ENC[AES256_GCM,data:f/7R7CX5i5q4WD13mxZzd1SEU8ktzY1FcCeCuf6c0lahm4GsdjP9SpKwEb2O5RfZrqvChH+1UBfOfxbr1xktT0hpRhU=,iv:LMouFkGatpCgXwggdkf1pUGvuxnVTY2zN1exrh5CGAo=,tag:GSv7GHlBV3dt/7Gw7Gv6Kw==,type:str]
 cloudflared:
-    tunnel-credentials: ENC[AES256_GCM,data:acmC/k4WbDlFqOUPsdBIi7HsHI5H3e+Pr1h/wU5zbJe2T9TrAhz6VIWBIz2tP3OdWF6ByOHgMVzCo98h7sL83hBudEmW99VnlrwIPUi72fKgr15gMCi8pCSWALb8NVzwf5CyPQfroVExey+UyX2Wy2Jr3Ut8ZWJe+wpjS+0B4BJKje7ipWRZs11JvG6khqWmG380ovLF3Sp0Djx21edwpVd1seWq5buRTyT7xa0CyK0bshQrBWnlitSIR+Sum/Is3V2p5vdHMlONfGUS2mUnKRhsp6B3tg==,iv:Cf9fSIeqnzfdoYugTtrEjDPGfXbikYwGDTEu8uwEru4=,tag:9/4EKjz0Szaw8smrR2biyw==,type:str]
+    tunnel-credentials: ENC[AES256_GCM,data:ejaGq9uZ5vYHg15+o1DswlPlfE33tyffSDMYmPfpqeQ8I4Z4Mpf8hL5tJBFGcvW8ERAHSTmFMo7IBUGCpmIn5qd/CYScHd/v3TNNO87Fezabx2em1I4C5Z8mEpcuFmyXu5REQzNVVi59/+ygNhRHQCCP+8uJlqIL0YB+Df1fKlCTk1vyZuujUJXsIWYtTzyhJcqSS+GvRTZlDBGCxVwE7FyiZPGOuug8/zy7GLA2JQeiO1Za5GRaEwPvC+5+DjuUZ4IJdDtJIlofMq8re8kj977hAJ8v3Q==,iv:/dJeQhA7SsUZ3qV7fqUKf533WlyiltTZEMZPllr5iMw=,tag:A69uhTbB/8EaA+4p5ZPCwQ==,type:str]
 ssh:
     freeman.xiong:
-        id_ed25519: ENC[AES256_GCM,data:fTHpCeFVNcLpcLQMFcWHGzTWBSoLG0eu4hCQl5CRH4xxKr/I3XvP+IXLYvcGEzLyXwkvl2jaGbIR/NJSVqPVHgpJMJxvhQ7M4f3jB/7Xl1pZm2Numnw0juxTO4kRX0x3Mx4jPkTf73tg/4M1SZz9oiLB7XPWU3F+JOBwCDn2Iu34xxT99RrW6sgy1HmE0I3S4CvrzC7uA3HD5AP2RnuHgXcNwlMBPb47Y/3C4VmN6PlXwLcO8bfCSyrSxl4FLZni6yhL7Ctr4a8CsHfwd7aWtgAD960x3kVbr0R2dxtqaFe/DZDBQmW3iQcCD7an6wodJyOaCqEE9vx4c2GrnlY3cxWmEMiRWrjblZSdAiEeL3dIeJqctm6y6m9u1TlMCnFVd5DCv9wky5jGxYNknZk/c3XjxLkvjaVQcykQUfNul+s9DyqG7y+TxLn05C31eW/xE2QvZZ5t1ym+7BJqW+wRf2c1yoc9sLYf2y7gnLTQhapvChFT6jLXEy5eK01xyAQoTaJ05dLwEzr8IUzA5r3F,iv:6BML3A+qjLcIf7nb+xjXv8g2EaDtHMxiMW8Hw6vTSd0=,tag:gkSII5tvjkPQOZ8lJqEzFQ==,type:str]
+        id_ed25519: ENC[AES256_GCM,data:K0YgHVMd8TRo/+1cJQEy4JeWY5Q5BPVhBz6gqvYbolpWXNS75ksdGshLp4sQ7O0v2M4ONZ0x/EGLT5V5/Q+3HXLctsUbzIfJa3uEDZ/jtTmKO+Esv/W/esSGcNsWSN6LICnIYKQfqaBI6+Um+FUFbvhkz/aUztnqm4Qz+W8m3byVELuqKnuf0wMfPPnSVUUBr8ZKJ1pivrXH0J6geNIYKoigB6hQQKuonMZHLK0h4t3O/2XW6JwRpvbAHc6FvYORvpqsDYeiXaAPQbu66Ih/nn3APSBcf9Y5CUB/DIF0Tr6nqa1uawdBQg5W2KGHhm0NT6qkXXt9+anjFlVPgD4poMkO15VqQJxXtEJueWkHV6f3VCVqJFDZfc+K0hTOrWNAC8LNbJg5IIEs2OpN5ys1Jsgsn69ZKKkLpaMwMVLkI2UI713w8CToCPwxjywQ8oXAxhrF4bU/l2ax3KSKLq/3wHwvgbSkhWWDKq379sonuqv6jbVlRuzH9qYiravb1yduEixOWzgCmSlZMVxSqxMm,iv:GHTr41AJapoytmELLsVx0OIrWkynALERIGlNwX2fZIc=,tag:v4VB6lhuSHhECsjfvcQgvQ==,type:str]
 oath:
-    seed: ENC[AES256_GCM,data:EpVq7Z857Oln7RgfQWNjwfKtZ87iugQ6Eo5yuChmAneVnWADoMrqGA==,iv:4b3qTyc5mUQ8jxQkvc87+/s+OD02rU7Ryi5Wo1Zf5bY=,tag:oCywx5ioEkjJtmmwMHuCkA==,type:str]
+    seed: ENC[AES256_GCM,data:/PTybLV2f1iCh/4OaQAtY1g1a52wYhkXeTGvdLSZh9kzAL493ZYuEg==,iv:Hxy/VbhoOOk4yDhRLjN0W4Fi/FETvOkjZMqNaZYMdIA=,tag:W/RI4qL/uotbB6CL91oXrg==,type:str]
 user:
     freeman:
-        pass: ENC[AES256_GCM,data:c9dQ1A4YfBxmf7/eP7g+lMLvwXiWHrdC8nG7cl9IFJuG/7g5CY9Z3PIZEPF6bcJUq+RSHnIr7GvyknFHGWH6dVByPq2r0D+yXOcFWzgrGAqphfFEntFXSCbFijCrRgANhMAymjed1aNXBQ==,iv:DHOkzaHZFxgw2dd3TeFfJzDbheudAP+kuQGnkh88Lxg=,tag:0mYjIoU/y7o20qdazBRp4Q==,type:str]
+        pass: ENC[AES256_GCM,data:9O90NMPXoIomQDNDZcE51oykoy5B1MxBvU5CdnMYVcoXcsittMDUck/DqZk69CbdNZ2ypO2npYifFXouFBMjVnycUf27jglUOiFmub5daSPzwgbOhUkarmbDIkR6S35ZM5fMcfgwWjh5Sw==,iv:pu2IDrY+7usIiWwqgmZ/UHSSHtoG81BspOWQmpRtnes=,tag:yUp9pruWJXm2rRtUdMM/cA==,type:str]
     root:
-        pass: ENC[AES256_GCM,data:8aENubkYa/E9cP9YLdFCimaqrGC7Pff2Y5KEkF6eM+RnNBmicxMITyWB765f6kh5lYcJiqwyTAgND+RRoCELO4xFFkl1FiuGMmqMo/YmkBo+vPyAtbbdloaTIuuwwBvkUjhnrl8779SSow==,iv:vIUzK17lnnLZLUaErl9owwxiQWij0MyVmSSPdOFxdOM=,tag:0dWeM0VpYUDPyqivYV4F7Q==,type:str]
+        pass: ENC[AES256_GCM,data:uVRHVmqxVQzlZqexzh43QM5n7oV0WhBpsaMPgGonELoCEa6W7Kw5z6uyAthRb+y7pmVNPxfryAKK2KEfLYdJ2nJ8RNb8kNqsVtHkzregnO+POCx+pT8Wri4V/9i3jVNazcN8T/4ahCWiWA==,iv:9/J9WZzDvNPRrfYFDlkzux9Ww+RFZz9lyBvjAnzk0zo=,tag:rGINY4y4QfH83LYiTJl5dg==,type:str]
 falcon:
-    cid: ENC[AES256_GCM,data:vN3RxsbgJ1k4SrJ+EG1twNjcrW0pz9qKN93WCX7TU9JCbn0=,iv:HHNDevf9ZnWVUjYyMBnE9/avlC/PvOcU5XGAOcycRWk=,tag:sBH74xdr81polq3gs4iI6g==,type:str]
+    cid: ENC[AES256_GCM,data:Q/xDLnyw4ui4giwx2WdNqQYqSmkFkNWa4644AM+euF7KPak=,iv:xmQW1rhseAt8ZLrEjnwh0XY8oe/UzE/2IkFJKp2GHE4=,tag:DygiqeDqDmBRAKkeVUVVnQ==,type:str]
 acme:
-    cloudflare: ENC[AES256_GCM,data:MBuSA2HvCZF75hPd6y80esamY6kjWJc9wUBk36UHYbdDj9Iqeq7d9/OGTtymMebtDObE/XWsUey1wjQIsGjT0Lzim9YWvcr0nprKuMg+Y7j5beHHObHGgQzgo5oq6g==,iv:WbtFhDs5RoPvoMsJSZkfzriq6Mu3ORf+CF+mF47pg1E=,tag:omn1Uq3JbOez7bJ2uPKFcA==,type:str]
-    volcengine: ENC[AES256_GCM,data:KG/wuYJxiNkj05MTbxfmtXWyo0mdZNyXkFwzmB2pd6gxEBWg6z+vj3xZjHBfFoPQ4ynMCOaJDI5my37yqfWkoVLe9sm3wvutvW7ocOnSJkg4vduhUKTuGK8LZkB5dOnyLYilaFozlgB3W1MLMu+JsT51fTcCKMNUfjxxdgcQk5dBwzUx94Wy0oSbRQ==,iv:A/kUdBirX9eUqCEp6G2fQ+2tK3VVUz2jtkY/C2i+AaA=,tag:icWVosX+3QvMLJov79W/rQ==,type:str]
+    cloudflare: ENC[AES256_GCM,data:T7ft2xZfQ047tfZ8LAT1U1+yKdqN/dEvjURnRENZEHgAXNJixUeXrGIDjdL3MCfo/WQlsBfodr0E9JDdqedM560LYJf+WP761qVascoUZfTJfNiNkRC/Tdj9PyFmjQ==,iv:P7KXAJ+1tev93x5S6rAA5vUTO8kIIGj8pWhOFioMPJo=,tag:Ph86XbI4oIE/26xZaOuTSA==,type:str]
+    volcengine: ENC[AES256_GCM,data:y5SdkXfBOVDThB6djhBtkuVChK2KJEtWxSiNn0WaNCUgppP+pPQ0nRwO7BXjG+26ge1FFiPPPciGyhZM2e8Yvq8zaiq5MS/+4XU7KPQ4OPOQv2ZEAG/SlCcBwZD0LS2lk8gROdM4f+PJXNtLNygkeG+ahH688xTxW0mL2wxabtCS41Ur3G5vqd3lGg==,iv:IG1pE5ITiPvOM8op+wH3PPPqWW8M0PYPpF0qz8TPOoI=,tag:B7l4eD5JxrWLsNbbzQBalQ==,type:str]
 wireguard:
-    office: ENC[AES256_GCM,data:qXoUVrTCHE3J8ccW8yQDn6TDN1hNiUX55Qkihllgcis8CNZpzsqa09kmPnE=,iv:hpGWTSD+bpJFgFii+j4Aweynm5K3hb7PKCt79XIATRo=,tag:YeP/LlLMsy0Ojg66VUsObQ==,type:str]
-    tcloud: ENC[AES256_GCM,data:YjLbEkcHfMgt8oOD9CO0Ipi4aoXr2pE/JPoqtz+kbpaq7BogzSM/vgvoo7c=,iv:x5mBqPTCu4wpcfID9A0RjfAxjG9fR8v+QOVJBCApaes=,tag:9/CxhxTV+8Ps69H2IA0r/g==,type:str]
-    game: ENC[AES256_GCM,data:WOKWuU0eoe6dpSysZs0p4Tc7RknETYaHksRUKMB4hw+POt4tTeM+oCi9aoY=,iv:rkyPMGrOwK5tUFSISEXB4HYWCV8Q/Zk2U0wZ+H4aq0Q=,tag:UYQF2ZDovw9MhCUhUk47tQ==,type:str]
-    game-office: ENC[AES256_GCM,data:gHF3W+sak91WHVBf/LLIc8S9gPyDa68OgcpcepirU268rvaAhPJU9sVMQv4=,iv:tXAEN4ySR0qLetOObVu0njN9mxcpotmqwSWA7r+J1yg=,tag:PHZwZUkkExUpSShE3y+dGQ==,type:str]
+    office: ENC[AES256_GCM,data:p0AghZAham6IohTmM/TNABpeUB2BOBUJ9Np8iaAwGaaiL6OcdyPjPeURj8k=,iv:JEwV73k5kQiqFasb2oLFRLB83kGtNpG9ZjpFvIUtDIA=,tag:MhN8Nt3bSREwfMpljdWQHQ==,type:str]
+    tcloud: ENC[AES256_GCM,data:GzgPzZpQb9kKvZBjoqXH5LkLlBCV5QeWDwd4DmGJQyeq5HpETIde1Lk9C18=,iv:miunQS+LD/keRKVW2Jf6sfkRDRLorcUOEUIzbhZ/jNY=,tag:UfSa2Lq8Spb+9Cwie+JGXA==,type:str]
+    game: ENC[AES256_GCM,data:c3Ua09LA/fNmD77Ci3Vtw95oGSbhNLQuGz6h8fSzBBdtb/bUISRBzlr9X+0=,iv:Vr1CC1LNTLazzBababvX9UIyuT1KGBfakqRns7uiJj0=,tag:kzMa5P+5lAz8RANWSMR5lQ==,type:str]
+    game-office: ENC[AES256_GCM,data:v+h/qsu/fxPKq8/o/5/QtswPKecgkyx4b/YvWUeKYiAX0Wi3rjiJyRilmtM=,iv:9rc3R7J/7Nd+UOUO1RIwowTv0FrGOh9oken4O8zoCco=,tag:9VhGcNS8wkmnmpEXWd4xaw==,type:str]
 database:
     postgres:
-        discourse: ENC[AES256_GCM,data:0rz8ij5BqrOW,iv:c4YrHJHIGCG2QxUsKfLvWrIvll8+G6OYf+vV3OnZwG0=,tag:sqyFYvCnhxe0FtQC09QA2g==,type:str]
-        gitea: ENC[AES256_GCM,data:mW6UsKc=,iv:MRlICZAPm+n8EgsCBhmeniH6TOUv9FlXo9PvXGG1mYE=,tag:bl1wPqSRBfNYTc46XfoZUA==,type:str]
-        keycloak: ENC[AES256_GCM,data:w5Tqi80Moxk=,iv:dMSTTSFC4hS5mi5WMd1f0LHRx0jUl1me5QCi+WR7MM0=,tag:gZBiEMH9hylL4V3QKui/9g==,type:str]
+        discourse: ENC[AES256_GCM,data:17SJOaYqmZ9E,iv:Z1/72sv68TcteDzpsjpW43YiY1Lozy902TC4k7hJIY0=,tag:UgNBEoKj9L7vaI8nvJi9Jw==,type:str]
+        gitea: ENC[AES256_GCM,data:SI6Efdw=,iv:yfseTNDCDcNSGsJOPCQ8qd1HVCuX0PT7H6BsEX8otNg=,tag:h0kEpiFh4e/XhrRIZFJ6aQ==,type:str]
+        keycloak: ENC[AES256_GCM,data:nXl1d8/gUx8=,iv:m4NNruxLzi4HxlHmXdcN0qlltsFLvnjnwoORhCiyV38=,tag:J4JIG27OYsb+Bi8qSbml8w==,type:str]
 cachix:
-    binary-caches: ENC[AES256_GCM,data:sQ/NTNgoaHqx4w3IP7n45z5n139LKyhz+3q7GE0yZOnpzaHrLlLKwjoXfwrztsFPzXWIrZ/E/MRdzSacvBE0kl0UhcTUEq2n7o07u91B43cOub0g3hejzVdbxq0SLp+eiSh4oUWYgS98cwmPW01OLym7nbwk7HZJ821yIn/UaXUj29gKEGA+k1+N83lLeYtiRjnB1aOxSWKeO4eX8AZllLtLgksvUweHI58bUXfrUWv5ZBFjxi+weHiq0K3dPDA/sBtpflHSbV1Vd3LruQRJQEDgBjJ8PonIEGQ57OPf5Yc/60wlfhdYPSqwcmxPoHTD2rERQcg7bWEJY9IaXO4mdFILlvRSqOkAPo/4x8mvFTvOOYJ80Wa1qVO8pw8ijYIoOPCqhODsNINvEQ==,iv:9SQLb/qqvsfjNGtw3jecjf55NHp6OUxHnYLxn8x2rgg=,tag:CHpAsoR/0i8t0MCjvyVe3Q==,type:str]
-    cachix-secret: ENC[AES256_GCM,data:32ZzC10RqQNADhVGKTEZVELn5Jcjb5veR2X8CwCiGalKXrnKMEsK4jXSZXSYu8zvewQFZkFpYgOdY23xW6MKAdvmb5KLM46lcXnNpeC7TrL5oE4dqE5unNcpS3WGThtFkwvzQ3GLq9pr1jKThVt47WaADW+wAWWGmmY7XEtLuPutN0qsb2+/FIbsgGA68XBZlDfEde0zvn2VAi7fpQbefp2KKeCE5INtp3I=,iv:67JGhudO57R1JHqpHQ2RHShFRdoImHVi0t7T4wdtcQI=,tag:qJtYf4nnrr+SiAnsshpWqA==,type:str]
+    binary-caches: ENC[AES256_GCM,data:Afrhbwln7QDVliLjprmMkBBrS62iAYHeWOjqOntaWsMSr4XN8DVqg3TivfBAymNfYkIJuCgNzqSZtLk/+9wz+/9LM+gAujMy83/UNr38yZXXcIzMhiswIW42DbG37UpcS52EaqqVqTL6TJNWOoBaa9TxCKmkvXiisxrH0Ysigog0NnAZhMUbdMJ/cYeDARBiX35XYdSWlM0zDbaKQaLMJ1QQRQ/GHAkyZBfNS1UxcG2aQL6QL+G2Ed2AljbLYk5ZErsW+45WHnDjXQVc6doM+djhe62PuyZXcOIL4NuMP/MpRkBUp/eAaJWtqD3b7dPsxp21GcEh0s8cQn/vHzsE+9pfE7DzGHr+uBxzTDPST4VT1MGeNbrBzpoSENmjRJB+fZKnXRi8XJ/+7g==,iv:pisqSdnwwqll5thVGdAr+slbF5vlOE+R4dLsjmeXfwk=,tag:R9wv2UijPwm+Pq79NDqRpw==,type:str]
+    cachix-secret: ENC[AES256_GCM,data:ztWCF/YyEhUlWRF3D4VBK9ZYRGLkk8Qst7MBbtIPi7ECmTgcYfYEQTan03LkXn6R927w8v7HrZ+9Ry+/UnLZ2g6ffQuPNpqcsaFJpovh0UWzp0KPkKQxEbO1Td+ssZlCvjLlBS5Y6hJbYHt8zNnjN7chJ9eNcKUmqTfFjlLtu8NIbjerR/hxl8Juo0msoLPEFSqIcA/ijPXDGSnrzEydw7O3wXCRa+MVqd8=,iv:8ijlQ7h7M7/7wtLv5zxvdkse3Lg9ju687B04M0k0KBM=,tag:fYnmeEl3chyczqJKhs6hZw==,type:str]
 openldap:
-    admin-password: ENC[AES256_GCM,data:Pg==,iv:vrTVFBTzG+F8Vm2Klxh8TRDpZmjPc9mMIHfObwnB7kM=,tag:bQzQ4PUNudSJxSHL7QGB/g==,type:str]
-datadog: ENC[AES256_GCM,data:AEJU3GbTsVg5mHZvOU3zpNNq4qqb77HpzKDtR5WU1t0=,iv:uz/rsLP0FLWCYOoZ1XlJPYZeE2yjlPlc4u6jeiy5GHs=,tag:Wf2autjb/evbr8jBbllZDw==,type:str]
+    admin-password: ENC[AES256_GCM,data:Qg==,iv:FrWP1heBG6R6KFk5pg2k9KhwOwURb2Ow3srpPX5jFS8=,tag:6uMDaUCmUNgvdAB14nJQnw==,type:str]
+datadog: ENC[AES256_GCM,data:MXivMTMY6vhM4z1KXz5MWFwxQGPUmT4Yu1iUvHhM9io=,iv:HrVp3eXHuBz+qDwlXcN3+VojEMuZhRWfIFxkTiUAV7A=,tag:1mo1p0R8wwZcAzax5vZugw==,type:str]
 restic:
-    pass: ENC[AES256_GCM,data:Y2mAg3Df96iU/TSIad69a3ubqFgHFpFhO3u7BQJwuaiPoep6oYJm,iv:b6MoZ6PYfzsi7tFReMzQPmC2t3ypoVD8f8pIzZev5V0=,tag:oaeJO6UAv/6sp+Avcs/sDQ==,type:str]
-    s3: ENC[AES256_GCM,data:jFfTOSeJIBTKY8aeqfIHtTzOtUR0K6WzSl069pz91ZVO5G26O3LSgSWV29DYW3qveGtM1nNwt0b2QeDrvqM3/zSn66AR8iPZqkuuyBD3mD5t0ZIZ7vWFeu/2zGqUida36ak=,iv:1J1GNIX3u8GaIk2KJknoWe5VfZTYrlHTQLbhA6c53M0=,tag:KNiyG4yr9inFQ5rSZhqw7g==,type:str]
+    pass: ENC[AES256_GCM,data:I0mRO4OXwmUlvPrQEjlKW2ZoVdqs9gc4nAEENJ6v0YGWEMsEdEgu,iv:Rpj5n/I3sOT9mkrmbugicXX83R7i0W97LFg99qwPAEo=,tag:gt1Lhu8jxwdY157/+Pi7xA==,type:str]
+    s3: ENC[AES256_GCM,data:XsXWJICyM7eTQJV9zTrgqsEchw6YsN2RHfoe7eL7QR0z8ToDmD7RgA6qTKwlKcO7QjR7WLq4Jf5Tfr5YOMHfxDLMP15zfh7wLTDu7O5a4kdkXo52wC8NXgxriLz3YpcwRfw=,iv:BxRfpscLOHyjtmoSqOLsv/MBx1+mhGZMKB0zB7YDfSM=,tag:gSxFK8dNscuAi5WvxwAplw==,type:str]
 netbird:
     coturn:
-        password: ENC[AES256_GCM,data:eNDE+CpVDEIYv5+q1eIc0Srhcqo3zw4QxKIFfosiFK0/UgxdtMhcFQYn+Q==,iv:KMTQeh7G7oscmRNFsfqeq3dLFqkCSuA3ZbZnidUpULU=,tag:5KLtOFYbcIl9cyZMVmuNQw==,type:str]
+        password: ENC[AES256_GCM,data:b04Igqp7e+aK+MPe+u5PSHAoxfs9uEfd3hhkzpRYJbAld2UvHfcYGEOSxA==,iv:WF8POwFOshDOz5QWIhdhNvi6NH3aOQ1IuF/fJqdssIA=,tag:wc5AVlm2nDF2PICL3X1YJA==,type:str]
 rust-web-server:
-    db-password: ENC[AES256_GCM,data:bJ2DZ1J3gHeTbnVlGg==,iv:CsC7Ndh7IuefDi8S2yBQCwbnacqGnLdcdS2J43nHk8c=,tag:7IbTerU968YGR+74Oadrmw==,type:str]
-    oauth-client-secret: ENC[AES256_GCM,data:8cgyjwV8dFWsn1QLQ4vyM8inQYUrCs7zLZRIcS9OPDLD7jGNUBRaGJbAza1iDi0K,iv:N6HPlVP5KlHuqFZ0Bsb7C9qftAmBE0cB8pqWFMYRpx0=,tag:UfGSWcLEofMOeTuwbxGA4A==,type:str]
+    db-password: ENC[AES256_GCM,data:0wozSchUQDTCO7T6lA==,iv:WKMjbr6zLry6lNoqAzv/GATzlZlXmRbkcRpedISixKI=,tag:cbfmx4C3n6l7HqRS7vfJEQ==,type:str]
+    oauth-client-secret: ENC[AES256_GCM,data:jG3TE+C4oF23ds4e5SZjHLW6sYHrgSAXhQxpzi25Iamn0OS04aZS39wIqIt7a0XL,iv:BWE1tmy01Br8rikNzHGLgEURJ/Eb2C0hbX/RcVBpPs8=,tag:NUgEexJfezznJMJkEpK40g==,type:str]
 kanidm:
-    vr-control: ENC[AES256_GCM,data:6nlbZItyw058DyFBadiv2FYN95zn2wmKtE2tnv8Ekly+JBF2oP4afWAQuvp24T85,iv:lfivCv1fV86cgw5d5wnVX4c33a4bAXwCFpw03w5dyUs=,tag:on+g7FHIdszp0zPFdhC6Vw==,type:str]
+    vr-control: ENC[AES256_GCM,data:h49RJKd/mF1g3/iiE1zlN7NGKHTIzk3T/b2fdaoFi+Ns0c8sgZuTzkyoFwSUg8Dh,iv:Me8eX6VnJkD8Vej6Waq5lNpokHzwYELT5j1gRG7OEoY=,tag:8c2JGqwrf/kCFgtv1R6Ekw==,type:str]
 openfortivpn:
-    server: ENC[AES256_GCM,data:RTi2R4k11BxrKd0ECqI=,iv:ofPJOgrfFOF2lv9uY04BWfzwrwWxLvL9PgJkeBjDAHs=,tag:zobgPS+SMEJqgsoJXGSh/A==,type:str]
-    username: ENC[AES256_GCM,data:N47IPA1K6lgrxKWwYQ==,iv:unxODpsUZlbWGVFiIUwyObzykbrVSuafaspmKDVfj/c=,tag:VNQ+9GQ/MMQ+cydqJuLy5g==,type:str]
-    password: ENC[AES256_GCM,data:CGIuCD/MYPeOT/C9,iv:m/Cmj/u6+H5tAzxvvCwD/8VbavsHtg3+1ImFiWpcPCo=,tag:XvoEAppPb3kiYh2GZhAdNg==,type:str]
-    trusted_cert: ENC[AES256_GCM,data:MSFEO3Hrw0mOrXchzeJcbEaKWhCwBs1BZ2VPAWiRGdX1I2Aax7apV92Hc6hHM+fU5oKVnW+xKPvwZbwd7e6dlw==,iv:YQHyeGVMiWv1c/S3sbvMl4gjw58XifXiIJOWhkdscUQ=,tag:oBPVT7CMnaZb8OZfea+uDA==,type:str]
-    otp_code: ENC[AES256_GCM,data:KU+ED3Ix,iv:cOjpQ2f0eH6Dz5cf4QeHNTwVblGmztjFKLL8KhDNOts=,tag:qjKA+pDzRn1JYTvT2AsCmg==,type:str]
+    server: ENC[AES256_GCM,data:pjy/l/3VUy+hDCqHkRc=,iv:ejmVx1YaSuPg5I80GTBXKLOurR1NoDjdPfdFWAm3KeU=,tag:GNu6eNF8QD/9qYR6Z33h5Q==,type:str]
+    username: ENC[AES256_GCM,data:ERJ+1cmCRFsPBMkkeg==,iv:ebXDf3J3epGlsawTuDrpnSSHjtiiQCEDNpoA4oWyui4=,tag:ulUt4cyi7g7rZBLWpnxGtw==,type:str]
+    password: ENC[AES256_GCM,data:QHbgCwT6tgAMhyf/,iv:a+w5OaoPozoDNZL/syvkuiWY2hp2yf0bdzfedEql4F0=,tag:/sH9rexwNnT2XPqkpq+8Pg==,type:str]
+    trusted_cert: ENC[AES256_GCM,data:/4jCg9ZyxhVCBhclSKU65+tGtEJZE2vuYb0+NU2XM1FSWEjot/Kf/jr/Yn730/MUJCeTN4CoG1cvg5yvaIToZg==,iv:CaMG//vnf7FoNc+Al4hZ4x/NojtjuRjHvjoXz2aBCgI=,tag:lcnxyIMIjByIZ5iIhk5M+w==,type:str]
+    otp_code: ENC[AES256_GCM,data:98+PvrcE,iv:Jp6/oftBFrPdcZ4QEA/Scp/dF7rit8GGO+cDR3gTuQw=,tag:0CUmMohjeQr0uvaOyDHXNw==,type:str]
 api-keys:
-    SILICON_FLOW: ENC[AES256_GCM,data:+vkkcZYSCPVGVMRi0n8ZouPJdSmDt4c6O5duGrW8J+/07SXnuranJJE8iMVHC0qwQbw2,iv:WCSKa91hUWIFROtUdnnYInJsU0kORL4viyO3m0PrHq4=,tag:xLTBTIP5COqJWimOlJXlzQ==,type:str]
-    OPENROUTER_API_KEY: ENC[AES256_GCM,data:yygFC7fNX+IU6I87DEWbxWRcSPiGH6fOMIDCIYloA8D/QwFBZ+RND5V5SgR7ESe0iPR7Bx5M8oxVpetkjAFnktL6NS6IrIw2Mg==,iv:yYiSvn566To3prXHycJCnRTxlWqSqpxITYg0WLpMV0g=,tag:f+plKaZiYdUI/i8Oni0s5g==,type:str]
-    GEMINI_API_KEY: ENC[AES256_GCM,data:yuDBN2T1E68CR8EBdzKB3zVWewKO0i6ki5ZeqL0fNJUod9xRzTuq,iv:toH+s8enV187sS0yhmheqogV/WZsKd0wmq7828q97vA=,tag:ReRfI6b4IrUsNMX+maBa8Q==,type:str]
-    Github_Access_Token: ENC[AES256_GCM,data:0xIy69etyqo55rI7Wp2KX2iZ5s0dgLZV9iiSTgdkSvbCPd4SnWm1lw==,iv:M5GNT1lS8LcNaNgEyPO24o333q5mJOrUVaUO4CFeP8g=,tag:Y7jwMWpkny7F45St0mu0gQ==,type:str]
-    SLACK_BOT_TOKEN: ENC[AES256_GCM,data:ELrgR0dSP3E5qvdNVjsu+2iV8SkQILgC++J6bZUsLJkdBpOnoDcilnmffRxwivyEgSCdk7me,iv:tyapdU/8JIvA44+1iYJEM84VtSKFxCv/xg9WTNy+L9c=,tag:mp96k/QutukdkZ4y0T9zrw==,type:str]
-    SLACK_TEAM_ID: ENC[AES256_GCM,data:SEuJmgljTkmTqA==,iv:APoTImVxvF+wCcOo98nebVbhuD6jXIYHnxsMvYKOub0=,tag:eWp5sa8lvNcJi3XiFatZ5g==,type:str]
-    GITHUB_TOKEN: ENC[AES256_GCM,data:Oo9HuzoUOVl32vlQA7ARCEI0pC/miTtN/fqHzgU7RHuKYU5NmdTiSw==,iv:+t1d/Hdmo7zZ9x+6TXKar6dP6k/FVdF6r8hclH4Iv0o=,tag:MQnWozECHQNaKyunMHalnQ==,type:str]
-    VOLCENGINE_API_KEY: ENC[AES256_GCM,data:uYBHzCXkMWAxOWeZUkqw5M+1pCoUjdYsXQoLmrKDTes53tsk,iv:Hum5OpPCfjlQ5y+b+tv1esgUG7g/OV0e9URsEDC9/fE=,tag:5pr3z5JaR+0g8EpMZweSqw==,type:str]
+    SILICON_FLOW: ENC[AES256_GCM,data:PFFZ1hg8uDPwCNPlPUYbWpR7NmY0vsyXHnr9SlFCQnRykvodV6ZVSW4HA3G4uDxcxFRz,iv:Vl23d0PmgnIh4OkNoLUzXW0XA+yoljyD5/mAsquPIjo=,tag:Q99gG0GXVvaPGtjgMYi1AA==,type:str]
+    OPENROUTER_API_KEY: ENC[AES256_GCM,data:D+kM8RZWzJ0JYklWQbOCIvUj+yhneCiXMRZQrTJSQhI1hq9mNYUkeTTYAF2C/tJcuW46ONsE5M2ayheDCX9r0SNsSFuFcL15EQ==,iv:/ftAr0ceGjLW85RUROrSNQWqfMBZPNvVC6nVVqombkg=,tag:xlbPCjQjz+5c/70PAmOjqA==,type:str]
+    GEMINI_API_KEY: ENC[AES256_GCM,data:kDiiImMdty49fqR94SZLwBLWaqbjaXu2VKXygb1suNtQ0r3VjZ34,iv:wvV5SpVxOKfoXYdG3Qxfvqb85A7LcFqQJLPxz7J9eZ8=,tag:blW1hEH+e23xHHShEm3TMQ==,type:str]
+    Github_Access_Token: ENC[AES256_GCM,data:JOciY22z0E7MrXgY/g8ezZmohSH4RFPtlSqNNDZev97AHefBvUd26g==,iv:WHzjadcmVwroGdlHKMniykcDvf+C+e+MKIefOZ5nqZ8=,tag:4wFKPz4LjZfycBHxfQOgHw==,type:str]
+    SLACK_BOT_TOKEN: ENC[AES256_GCM,data:udiPzERBzDL/kivWb/y3NjGRKkrTnxlPNgJb5iRViE2Z3xFYLdudzdw9y5YiRDSRmhLzs2vO,iv:z3oqmBMfv67xd60OyVF92v6UjbwSh2o/JyHRWvRb5n8=,tag:eV4noL9Tkm1a0+y1WR0W2A==,type:str]
+    SLACK_TEAM_ID: ENC[AES256_GCM,data:ix5pn3BzWZ88Fg==,iv:pW/W/X8/9Q5NEoIMkzbFIDTnVtqE8yL6O31XLiFsUAU=,tag:qotOx96bKL1eg02UvwkJWw==,type:str]
+    GITHUB_TOKEN: ENC[AES256_GCM,data:hKLXRjgm6lrtndZTVyo5QZKmO90AHpvR880ajJQaP9DAw8ezQququw==,iv:fUofEd7Lg5YljTBzAYcoOFAg3sG8ENMBBqL2AJpjUHM=,tag:9WvI1TsYNErtlpPrt0C/bw==,type:str]
+    VOLCENGINE_API_KEY: ENC[AES256_GCM,data:bozkoHSawrM8mjfa9T0IMBN+hNzY2MbktI3DADA3BVePgLez,iv:wVF7njGdsGupQKsy0m9tqRW+wvRh1pUeu+d/BHOheE0=,tag:y6r/V0LK2NPHa7FauvVxVg==,type:str]
 sing-box:
-    V2RAY: ENC[AES256_GCM,data:6stOS41O79zB8Ibd2zeCtHKF+Ol1gA4qEU/nEpBrPuuE7sLH,iv:2NJYQd2pSFSyfFFeTjY7WpnXgsLXAKGOK8uKRs+beUs=,tag:zY+pyufVdHmESsj4M2YqGQ==,type:str]
+    V2RAY: ENC[AES256_GCM,data:8HJyaZTSVa2Ms3wlMu4oW7paHGMC7saxqBrzwybay87eb7/y,iv:fwCxbasnYzUri3y8kBnBYBXCkhSNAxQSidlucIz3FnI=,tag:ej25WEYMLmIys55e14SPTA==,type:str]
 wakatime:
-    api_key: ENC[AES256_GCM,data:l1vVRuksqQRyiQcKTs8io4xzIuBIe0+lUon/ik+E/DPQ+biJ,iv:WJV9Hl1YzvIjTbXTvVSMinhoHkr6vBavWrjL2YXdEls=,tag:KtoHuVX28dbjFMBKeYe4Bw==,type:str]
+    api_key: ENC[AES256_GCM,data:QwM/eJBQOYNJSihJ31sK6OpJ7JZqTsmRueMX6+ZPD+7gLH1Q,iv:4/qjVoZCtPh6/5Xxw6vYm7aejaQTajDM0KP9eIXC668=,tag:iEqVJFxkUy+gYQFbbSMQJQ==,type:str]
 odoo:
-    db_password: ENC[AES256_GCM,data:CfSuug==,iv:8l71NHgr1KsiyeQB3lXH0X7M0566gNlpLiBMlN/z2+E=,tag:o9ZmAvTL6Z8NrcJWWQtwjg==,type:str]
-    admin_password: ENC[AES256_GCM,data:wsguleU=,iv:vXcuRY2ic0IH7fiYCjJObt57pvo2dZpCvfXmgGqxRhw=,tag:FClml8mR3AaaaRJIad80iQ==,type:str]
+    db_password: ENC[AES256_GCM,data:7h/H5Q==,iv:V3DKWnJbgYj44EAxO//kflgXQ4C6eZ3oF5uD+VT+ruA=,tag:gdDRCZeTyHUWmztSjUF3oQ==,type:str]
+    admin_password: ENC[AES256_GCM,data:D4RqFqE=,iv:7ZQl23dyZ+gkOtzrAu/Lw+8+JvLGqaegeakZBjgNMXk=,tag:DymGK9MERBvh6DkRsIGljA==,type:str]
 hashtopolis:
-    admin_password: ENC[AES256_GCM,data:46YYOi3e6Hd5kabqDr8pESkWvA==,iv:hnpKa5HPf7WGe6IfMMu/wBnTNrMIvFzskmv9rH6k+/E=,tag:n9+TEpVNkesv4nVVJoan6g==,type:str]
-    db_password: ENC[AES256_GCM,data:DzE1LSyB1UsHJkzPpQypMO+T4cM=,iv:fmQBHHgLEGGdPRRUW5OLhFWsUS8TWvJQ9YUDm3onWvo=,tag:EnJMtGJPHuL2rojb58s4pA==,type:str]
+    admin_password: ENC[AES256_GCM,data:z+Qs+A1LrcIAiR1jPVNCqGUE9g==,iv:mYQPi52O0hSocxeLbx8slbim1LJJiOZ9irF60ywfcGc=,tag:J9XCRYDDE3+SOqci/aeWiA==,type:str]
+    db_password: ENC[AES256_GCM,data:6P23QS/JOZNdJvHVDPosOhR9PM4=,iv:ldvGwleMnCQ7huLzIJauliSrlg4DicD6cTLKXZM4ZHg=,tag:DYBwh7n/PUVtX7KXx1gzZg==,type:str]
 coturn:
-    credentials: ENC[AES256_GCM,data:m2VzDSXE8jpkmiFpf3eCj0oD5HJj0SnVzwP55bCqMvwlZghVfVZ2PjRpcYysrSqE,iv:K8Ssohc3lc7gz3e3J5apmZCI3lSxUK0lAYrP8c49a78=,tag:5/Vr17Nf7gFxZa1D3pN3Aw==,type:str]
+    credentials: ENC[AES256_GCM,data:NE8sbTUQ6qdolklIy9MM3FvLIs9JbUXiMZ+Vr8P/PT/mJPpfl2WHiGtxZjVfcS1F,iv:IZoCPIQGy0O0xTUWk09J3vPqCDU4WxoVc0OG44fzRZU=,tag:j8xGERyte1/Uat4vGtg9MQ==,type:str]
 casdoor:
-    db_password: ENC[AES256_GCM,data:12+4hNqvAw==,iv:dFWXveUq8J2yae5wJ3H2UyR9kwGKRotj4Nq3bsg6y1g=,tag:1SmGZXCOFX0xsx1Qy1kABg==,type:str]
+    db_password: ENC[AES256_GCM,data:F8J4AyugAg==,iv:zNEHN7f8BmTeNRRrs6zbBMYX13g8HHy7307lyGQuxWA=,tag:HThxrTfx0c646NRDITnorQ==,type:str]
 zeroclaw:
-    nvidia_api_key: ENC[AES256_GCM,data:usEfejacxdGVw4cDT3X6hE7TDV8+cb35FG+lGCScxB/NIb5gPZHAPiiWymTul5W9cA0fTIuOJnnckW2gIwkKnVMPeye43w==,iv:A1Uzg4xALTzPcf3R+0F10m8nWyLFjibooLPfRiyO7Ro=,tag:f2yWyrFqcviRc9w3wcwuUw==,type:str]
-    brave_api_key: ENC[AES256_GCM,data:oKtIMX2HdpioF32CUd1Bj9MrrZCmarCKl5b2Q+mtag==,iv:yPOHmBqh8SS4NbISsLW0ZHkwhdW/GAlFow/5JtO+GrI=,tag:x2Sp5dTuZ5BJw8zMtQBxow==,type:str]
-    telegram_bot_token: ENC[AES256_GCM,data:j2VMxBCxVowFvl7SXSNfGqYvyFxRVoC6/en6EpcUKmBgGYsRKAwmAXa/sip+nA==,iv:baVqPcCLAt4vdECG2p5vhFQCEyJr55Tfmva8KjnwffM=,tag:d8WmOyPSGqdupd+i/AbLlg==,type:str]
+    nvidia_api_key: ENC[AES256_GCM,data:h8uo0AVoKqdkabff1r3cgDwJbWXY7AqSd1Qwvh7pPTsPVr3hxUdfZbBVm8eYMmpPcCkM7eWj5P/xLOfCqE6TyQX1oTieSw==,iv:AqzbO8fciAax+fiyDLuYxmv/4beNDk4ep3aJknnsOLQ=,tag:aI8c/zLz3BKrMUy4hHJqCw==,type:str]
+    brave_api_key: ENC[AES256_GCM,data:rg2TK/oqURzPX5X5NseZGkfVrKEt+h9WfFY1bk5tfw==,iv:8s7x5xbnzfHnCKKNTFZ4KQ2DyhqKdPlAhRyEEwoOzD0=,tag:e11UINdvkdy7OQhTIcz49w==,type:str]
+    telegram_bot_token: ENC[AES256_GCM,data:ATy27upQJbor0yURH8MuxHETRKcHAmbKii69//+lGADi49oDg8z+7b6oYXjN5Q==,iv:flG2GU5yAoqbXFMUG9mvn9Bm3NK7RC9KIqSIndW3u48=,tag:SwBnSQLuTV0nQKum3k9h1Q==,type:str]
 autolife-relay:
-    license: ENC[AES256_GCM,data:GQq0rVEHAeFV2qe2PAb7Y4y2GBrDTaWRLsadi2/duxMSHX7qDQbmRSa6pOeT2pw0n+kSQkicOBv7a9ZI0Ri6kYE16uZtSyWTTc4kSfUcKiqjfAue/b3g4a9vIteMcBFp56GmsTh+9G2Lye/BaCi9mEYGRqURA8VVWeVWr0Htq1aOPAyfGFIFbJ393CiJP0e7,iv:8czHwkUQtRnKaIeFGU9mB/djosd74bL8RlUYf/13CoM=,tag:elA+kOHwNjz+59N8FS0d+A==,type:str]
-    token: ENC[AES256_GCM,data:rovEO+84hkKS,iv:rIAmaRl181gXmeOljMBllaXLUu0KOlttd4ykZl/A57k=,tag:OLD4+u/RshVtSbc/jhr3gw==,type:str]
-    service-auth-secret: ENC[AES256_GCM,data:x1hamfa+5yYu,iv:l32/4qZxm169hjJWWM/+VMEJSrBoIm7hpBFjo7Y3vT4=,tag:xsstp5W/+WUf/XkR4QOvyw==,type:str]
+    license: ENC[AES256_GCM,data:aBV/gzUgEohKKdUWiDEzG+Cqgcap9Xqd72GdaVo7aQVwf9W5da9t3Ew4TpaStTZzfdBh3YWeZwGCs95RvP98JBuu93tqqst24tCSOAqvUBTwg6rFiAuE1MlfVgiGUYRY3GaEg1Aj1t1ZBsCFdZha38oBOdMvW+dC9wkycdKb4T+O7MOmTrHi4ArBlZ1pJahK,iv:dwY1tAXzeRxpr7ofkD5pUUJ/dcAq0gT1EDi4mUnaaEw=,tag:mNaJtgU00Q9u13WQ+A/DtQ==,type:str]
+    token: ENC[AES256_GCM,data:CchItvw7y+/D,iv:oMeFNEQrKK6aOjjrxIsohCN4xgUvz3pHOX23lkcSqVo=,tag:MBaSbjF5dvXupdNAgt8IPA==,type:str]
+    service-auth-secret: ENC[AES256_GCM,data:iRtZQDKXHgt8,iv:uoKqatEVECIBGFOj9akz3k0jMozSXi3fjlinwdqU594=,tag:ABnHJijoP3QIeKlk8IZuJg==,type:str]
 sub2api:
-    env: ENC[AES256_GCM,data:2HuPwncE7Jrte7i+QSN1GoC0S5i6pzEDRnGTK+F3BIE5QP1anvRWHpwllUGdR28raf63AdNBJHUXY7daZX0idTRFGnw5sYd7fVKEpMieUDQBLAb8+0126bVLEUDhq8hG8yWEkvyzylrRc24ykK3NfLZTAej7VDsCc6Kd+TenMiCe8OUQMJ2pW4yPSD6QxWQnLKTPfNtAUBxfdogUl8GdsQqZwENNHSZ3Z5eQcbtPrrn3YvOnMeE1CZPPjhlqrS2YhLzO7NAAqqMTS24mjdhX0PUcsE4Q5eBg8g0YoSywH/zU3jZMZ0CtpwsYrwne0F5Hl7P8F/nezHs2ABpzbI5xbLO7/m7JzyzcfQIKzJ/v9902,iv:Vzh/Vr+zhRr7r3E/EiZ+xCe/YeEuOU19cPIuPoQBX8s=,tag:ATLVoMwv8RRlF0Gdo0lpwQ==,type:str]
+    env: ENC[AES256_GCM,data:9FJtLiwEM/2BlZklB9T+jsZyNPwOs+b+keYAvjd2EEorF2qAGJ7rLypZksuiTkJlf4pl9/+B4rQf9/Nk+ZwWKBESj5P1GX/2nI8Sh/2zJIadw2/Ratz2yaqYJhHPPwAS7DcWVuuTgHRIDOL2/o3zEfvvLebkiVtskxRzvM2VuoFvtY9mymY8dmaHcPmy1klhzigQvxj/B8jfUq5MGkpIRYFICFfGV/aPWO3TtP44IfaKVhK9pG/lM6FWoaxmNpNT9eLhsGooJfZIIiV3f4WLXfrL8AsuxO4Cy7hx3pAZhwk9jammmn4hmT5upsXnAvPmVj4n2TZginX7bGS1uymHTwnDmnqIKAXgYkBbZPtAXSgY,iv:EcT55uJ4oYCmWmSahvaON8hvd+BglLnZVQnCRnIM4cw=,tag:tzmRQT9kDwDeQ/L2ZV/AFg==,type:str]
 casibase:
-    client_id: ENC[AES256_GCM,data:HSn+vuvUPEJ8we5Z/akErG1CFG0=,iv:ttF6FJjRv/VLmkR9cuFkZz67KkzrZM+l0UoApys/5uE=,tag:9fU5lDm0fqDR72TeP4YKRw==,type:str]
-    client_secret: ENC[AES256_GCM,data:TMkNWrbnrD/DOz6Na+9eNeW4ssmOtq+X80T6h/APmtN4mGR9GgIG6g==,iv:heF8qU9h/aLOjI7I6nd6zfcqHL5o8CHZbn+t694CRSM=,tag:iWLPvuF1lj1bGzllDeDwWA==,type:str]
+    client_id: ENC[AES256_GCM,data:UXN9mFxVsEPRBCRlfy8ql3kmf04=,iv:onKaynEHeDNsOncHD76wxVbhSREkUHRNqIvG1bqQ08c=,tag:Iyity8EY0n973YkEEj7AIQ==,type:str]
+    client_secret: ENC[AES256_GCM,data:QnyorSMCNifKu39ggYpuDbJRfyDtcvHAk/wihIpd65TJZEbZ9EgwgA==,iv:Gt2Iq2Jt6IkOkilEfGsH1wJjcW99akbv9pkX1xYAZxA=,tag:xcz0uL+vx8E7qdRc4J9IqQ==,type:str]
 s3fs:
-    access_key: ENC[AES256_GCM,data:UCPlhSUXQsJCkCwXb25vp92ogxU=,iv:claFM2T35KXDl3YmSWAHUUrndP5OhhNFINdk3rmrCfA=,tag:mTWwGTWmPjyHTfaD0vtlig==,type:str]
-    secret_key: ENC[AES256_GCM,data:DoUXNasDDdUyv7RT3Zut+MKRdQ8rA65NxlyKWJN9498pw28EOWQh1g==,iv:k+SDLvUGo2LVS2ZW7528nuZ4+g0TBssOwrzUzGZ1uN8=,tag:3vPz0IZoq7SZn8Beh/7ckQ==,type:str]
+    access_key: ENC[AES256_GCM,data:bKWZKmPyEf+JRIuPh4+qgHo0nDY=,iv:iBP3cLE4JJl8xjmuO5vJk8HJUBUqajJXl33yUkYMkaY=,tag:CYx93mpb+dtFjgTmjKn89A==,type:str]
+    secret_key: ENC[AES256_GCM,data:TnUR4/JpH5FXOHVE7lIY0gS5875ALJ/ebTg5q4eAe5RKaNifCK7jVA==,iv:Jlb0PEKzKM2StB5jh/SLdQEGuCfuA7jAyzDc88A1S0g=,tag:vZHKonOJzxQczXftjyiG3w==,type:str]
 aria2:
-    rpc-secret: ENC[AES256_GCM,data:hOlBF2RI8fj9biAfKeQ+5en2KxfwDYhvSzakOXyQWqI=,iv:GPuBThOEdrFMSWGqtIoKV1Kuv8Jbe3PZAcNWbZH1B9w=,tag:3LAUC6fxnRWpmVn6O1BFjA==,type:str]
+    rpc-secret: ENC[AES256_GCM,data:oJG3/ttyrSZdsKfKbzD9iWLdGJoCdUBHt8kJH7c1Dnc=,iv:hZNRYrZT4Ues1GgJ+M1oEQNJqMnQy+6KpRmGdRWkhl8=,tag:UGVDI0HRWh/rW4Vzp99e/Q==,type:str]
+cc-gateway:
+    email: ENC[AES256_GCM,data:g1zm9z+uuOonkH1Wwnjc0VTNq7j6fwmg0EcKrJX7GxXIS2u5hd0=,iv:oWFLbqyeD/GPfQ61UmVF7WP0DJK73tTxoaq9DELpmzs=,tag:jnbLYZWiiwsGi7FiI7hS3w==,type:str]
+    device_id: ENC[AES256_GCM,data:H4HsAY+vjBZbwbmMY0RwLN5mpz/KIN+zeLX8M22vu8PKyVZa,iv:YmjyXw3BOrA0umIVDc5EmE8MY3KzagEzXfMtN+kLiIk=,tag:LkglpcMyBi0DVkmM3P1riw==,type:str]
+    refresh_token: ENC[AES256_GCM,data:pL8ik0bCVOfoBbzASu1Q5vOoLDXwfF8do12e1ONFq0m54VY0KrnxUJyfeO/MImVbP1h9n0wdEt9kQAjW3UCs7g==,iv:9jV9Ba6nBqBkg0ldf0YlEoBVdCz33GY/0kZeES3OlZo=,tag:YZ8HP/fUkUN4HhDOw8sajg==,type:str]
+    client_tokens: ENC[AES256_GCM,data:WjfhFp8Jp5lbl5xV5migDdGMzDn9G+9p0BVk2hKgwFTDlp0RfLAA/PmPFOB+rek3A3LmOU+YNUUAEaDb4yvxXt/zTPQ=,iv:UYVv4bIftYTQl6YDqE+IHANeW2Sb/Qya+P1p/l5lzNs=,tag:pNfE/KzjgBrrFEdPsA176A==,type:str]
 sops:
     age:
         - recipient: age1ss6yryyyma55atqs9mr823q0s9fqlu9rdh6dmkmzhxq8jvf635qssp5cuw
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrZU0xNHF2NFltamJhWUxP
-            a3AwQnp3QmFyN29xakE5TEo1QkdmdzgxU0VrCm5TTlhrR2czeFp0alIwczdpRVcv
-            d1JqRUthS1FSSEFiNmdRQStycUxIbkEKLS0tIGl4QUFVU29wWTVzZ0JtckxDdVd3
-            d2ZvR0JGZ3FTNTRqR3phWmc2Y0FROUEKae3evOC14jjNQ8Z2rEB3TbfcUQjqchtX
-            yymyunGEsi7Tu//0aunGKywq8O0RCcsjvvGxhb6S0Dnm4UbIHftdHw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYbHR1UEcyWFB0UVN5NHhH
+            S2RQdTFNdGl4WG9aanBSbUcxM21WSWg4SHk0CjgvUUlIdi9QMFRnanhaM0I4U2s4
+            ait5dlZ2Qlhja1lGc0V6MGswTmJtUVUKLS0tIDR1OUowNEJyYUl1dFkwMmJYNCtj
+            cG1pOTRQbkI2Q0tWN1pZOE03b1hnTTQKNGY1zWaCiG/U51+eKTd3d4VD2cbsuZCa
+            7Soqw/QnIwJzsArlgPR+JXPBbOx2B/qz112Dd3yWop20utm9AyFQhg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1nqkt2nakrnjxqvpr9h99hk828e8407af26yvdf7qn3ce5uydkqwqjgkt8n
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhaS9aalh1dVM5SjIxVnlz
-            b0RaaDhiT1k3bzVPOWd4ZXVPZEdRbnFoWlR3CnZNaGd6cklxTGdtRjFZNlMxaDJa
-            NlhIT0tLRk1rVWNkWnA5QlZwbUV3bE0KLS0tIFJCSEkrcHhsM1JvaDVKUVJZN0RY
-            bU4rdS9lQWFLTi9zdzk0NE04UDc5N3MKYyOjmcpfpDRRWJyr2f+/Vuj5e1ln1avQ
-            qAmURN1zPKUPhbpBBu0e3Vj7kW59Jp7Hk5S5PV/ElRlkmJmPkamqiw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwUVVxRUgvQjVwUzcrOXZC
+            U1BkQjNsWm1weHYvMDU5Q3VKdlBTeFo1ejJnCmxGOVBvV1pHNHd2Z0tONXJJYVhX
+            di9iL1pVc2paZm5EcG81UlhUb2dXK3cKLS0tIGowazRWM04wUzhrZERsdDhIZVJx
+            VU9FZEt5ZXE3QUhpZFJ1QUFUY2NnWWMKtWfy9kd71BLroTUFFSSmRv+goBliKtB7
+            Bol1OwCl+QkZpo1Z5sHwlN9od5qKAiUh+OOaLL1/X4pYqU8Q9AJEXQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age107w29mcnleyvvza8r9p3pkq6v7pqg8y3uvn9vp0pa55yrrwa757ss3xg5x
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxMGtZMzNsQjFzelRYSFox
-            bWZGS0g0eWxPVTNJVnpPWHlsS3F6R0luUFhJCituTzc5aTRVOWlRQ0ZyczRYVi9P
-            YUdEVWZrUkxIUy9CdjdUcTR4RUZsTFEKLS0tIGZuZGc3L3JrUHh6ZEE5WCt0c0V4
-            dG5rMGxyZlhRZ1dQdUNIUHRrU2dpWlEKs22sGyICY3sdtzDJj9/9qrfSVJPADxZK
-            FUS0CO/ao5lWB2a1rfmUGN8pL628fEgu+CXdFutA30YcWFuoDsHCpA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjeFRjY0ZicTl3dlozb3hI
+            ZFB1UjR2SHN4WU9zTjhYWkMzQVNpejZsVmtBCm1vb3pWTWhBdDdBN3RncGhkakJr
+            RHZNVFFZaEI4NE94VFNvcFgvZ1NvUU0KLS0tIE4rdU5jQURpR0V1TTROVEpuS3N0
+            YWtNT3AzeFFQeVZWSVdFdGZJM0VlZ3MKd3/nhUQghOyXavlEgLbD7j+wtLcf4wxV
+            NarfUGzdY+nhzD5wdZfbDI0jIFq5Kd1phECfI3rLHr3AogW6I+i8XQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age19eapwgdt8ufhzztcs84jtqyyymh5ypld39mq3kc48aruz7jmu3gqgysyle
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnV3VETmJ4L3ovL2hiS3lF
-            YVNZSU9wOHoyb3NFd0duZU1jd0pXRkhlaWhZCkcrdVR0WWV5aHZucWczeWtVait2
-            cGVOdWorRExLaUFMWEpSMGFiNVpDRlUKLS0tIC9heE15TGZpaGRGUFNmRGM1ZlVh
-            TXhsaTVjNWtVVGxuTmZlc25zWm9KZ2MKLScIqtUruNJF8s685MwmJiduuWQU/XoD
-            Fd2GiXhR8ZOqMQkxXO0Ldh/58hzxPVxsxV1n4pb3aIXujUEkFIBt9Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyM3JsYm9mZVlqNVdpSDRa
+            cHdva0VQL2hoTHczVGpDOUd3ZS9lbFFNQXl3ClVuQW01bUpCL042YmJvUEIwRnNL
+            TS85MHBGakhVcHI2ZDFSaEVQSGplNXMKLS0tIFBmMVJwZ1d2OWtBOVBRbDFFQnFL
+            TWZHYXFUNkk0aEJMSnlFN0ZNdS9laFUKHtO8k6fJ11sUfysgd2G/SbVgE1lysMd/
+            0yc14StlfSlRcKRdvBLezFeTcxqadaeZYyonM+g3BaueX+6mALajmA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age140gwsatv8ev09jwnyrt7wmhwtf652hhs07y5x4nwjfy06wphncmql2zdkj
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGK29xSmNWa3pnU0p4R1hk
-            V1ZmSXRjaHY5UC9XdzBFWHhvQlpIVjVmMVN3CkZiVTdSR1RBdlFmOFZheGRMZDBw
-            ZXc5ak5RUlhnYkdXMHl0M3hWSVo4Tm8KLS0tIHEyVW9yK1BZdTJhaytJZ3BlUW5C
-            dmprb25HNWIzQ3NHQzkzZW1pVVYyVWcKEWPjDwtvye6BypcA/cCTJrW+U7VUv3iW
-            mvqtqfkZGO5UluzwR+RVdWr6mMV2Y9S16mz7IUYhEX2MgBV0u4f0MQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvNldNSEJRRktXR1VKb2JC
+            NmxBMm55b2xEV0U4d0dQa21QNFJ5bmN5RzNnCnlLTW5MK3E0RUdhdVppcngrUU9p
+            bnFmL1V5STh2Z0tRRmdiN3NDREVSbVUKLS0tIEJtVWFBT1VKa05sRStyWE9wT3dl
+            aVVtZXVxa1l1TE0vUUxDTEV2dS9XWlUKCsQ+nGcjLTEUIhlq1bMUtc/USQ0uDzMB
+            Ac7i0IqNCR1l2TEIqix7Eu3/FWXGgH6FGjqzwFNtQx1AV8cMJh7O/g==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1xm5qgvpmy6whs5jqrdzde0l33qktg4azst3zpyr7lgg5qh9cqfjs56e7d5
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQUVFld1k0M09QeGZhRS81
-            UW9Ub0J4NmtDNmpBN0xKdlhZSlJoUjBIekFzCnhvRGVITlhGdzhvQkpmMlBoaTZC
-            cHlmZkRhMUlCOEFUMXkvZzZDM1hGTGcKLS0tIHFEQVI4ejJVYzQ3Mk9uT2lrQlFF
-            QjQxdmt3cWQvSWdyMGFQTmxDK1A0VWMK6HnUNFlv2xjB2uO29WVnW7SjRNhCViLM
-            7AazoRVpg1zhcjL9LOPASHIqNsZfnvGAvfHTQ0hgmQYFSJZH5o2N+Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQczc1d0ZOUFNSR2lTYTFT
+            b1NGVzFld1hDTFc0S2VENHhvQXFnRDVKZWw0CjZyd0Ntc2JnQm1mdVBEdEcrN0c5
+            aEZMTVJ5UEs1UE1RWHcxMDByVVBDOEkKLS0tIHlJTXdNYjh6QzZySkR2b2JobVBI
+            cFhzS24xTkJVVy9KcFZ6SFliR0hFRkEKiabyz03yOTyhX4NzC1ruzBJyNTUOCBt8
+            o/UataTVdB38VKvBuo7QcRFnJuLL4yhjXb7R+YpQ184gB7fJogg5wg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1ferch3rq8xyvdqmvws8qg247s2uxsjf4pul6430436rg32tchq7q3aj98d
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzRnJZNzZkYUN1UDJsQ043
-            a1N0NmNHRzVseTJDWUdjekxrWDZvN0RkbkNNCmdndmVKNzlNS0h1RTgvdUtFUmdj
-            RmtKT1R6d0V0YUMzSTYya1dTK1VxV1kKLS0tIGF3QTdSckh2WFE1R0tSODFlaXBi
-            K2RpT0tMS0xNUllsQVJHQk1lNkhyMTQK9AQTBpnAaDUiX0f7kzQ+FBjFU9yNc/o9
-            fBYC9rNT8Xv2My8HITNH8UgHaz/VABdn9KlFOYOHDO2gihoS2DP3JQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3WXRHN1FlSy9WSjBpVGg4
+            U29WRkV5OHhkNi9KSFpGMndTbitjaFdweHlnCkV0OWppT3pUUkVCZ1hRS1BSNVNG
+            V25DdWNmUlFkKzFJUW8vZXp3MnJjRG8KLS0tIFN3TUtEc1ZmbGNqSDd1NmQvNTVo
+            bXpldkdlTEJUdVdTdVpYWStodUZDeGcKwDkhdf7xW/6fNbQuXHSB37QnbA1/eaD5
+            Q2N8tw0YdMZfLbGqgzx+QOm47HUA8vsucmxlvtiP15fPiHt5NW5wGg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1gzyuqqta5820q5ve2udpuf9ccdqd3le7rgtcxz8zxa92cv66qp6s46ukq5
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWaHhJUEVLWjRaOUJlbnhK
-            YVQ4NUg1Nmx1U2tCTXhLSGdyOFFUTHN2b0VJCmY5c0ExamlhTnZVTWVWWVJrUFFN
-            ejhnY3l1ZHVsWWMyeUxYNGVGUEJieW8KLS0tIG1sNzNoTXdmR1kyZmVnK2ljYkVw
-            NWdjNzdiZXkwbjdDWEpIMVJHRnVzZWcKVxXftlZA2PfaSJ1Pxo3c9iNTjzpVxmIZ
-            cwmxKSXZN3AY4JC7UfAniY3fq5ov6673dvteOc+jXMrSvYzw5YYs+A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwYW0wZHo1RHNoajUwcHV4
+            ZmlSaE5yWHNCYXp5VCtYYm9sUUxFNEZyQjA0CnNQcVYybVVlSC9ISUo1ZytKYWpS
+            TUFDODQ0dXY0UjdLYnluSEcrczVLWTAKLS0tIEViM3dndkRVaXpXSldROXgrNUxX
+            bWxydjF6Y3JyY2RKd1ZKdTNuNDVXK3MKf8KNuLUyxUGiGBIY0JQIJ+p8y5pQYZIU
+            5xf1wmUeQ6FTs8K1tlcz9bLHhm0kFp1hCX3zbmc9GffLmmi35VUyHA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1e705lmnt4g006qpflm8wyefr23papuz3cq5z4dyctjp6u7qz2y0qzmmh5x
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkQVN3aGV4U0JhbEw0UGYv
-            ODUycEFSZWVhTWIyNW1SWnlIRGkvczFrZWhjCmpnZVVKV1AxTCsxSlNPeVBkSitw
-            Zzdsam82Y2pJa3pmR29GWEVPb3lYelkKLS0tIEY4WlY1SkljZ0g4N2twY1hYWUls
-            dWNCZVVCSnJWMGtEdXJuR1ErdTc0YVkKdZ8Uuwg3lRFXgYj/0CiiBjXEItu7k0Lc
-            W55RNvF32UlO07JBCOpR3JU8aT9wJEEtg10tXKsLVRMsGulpmiTxpA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKUHl1ZUlUSFZFSnd5STIv
+            emQ5ZVVCNUZZblNheFpucGxoUmlSb01TVlRBCktEYWFOVVpSdHZaSE5SVkVXVVVB
+            TXN0K3BGclUyL29SWTkrVktqZHdrWFEKLS0tIG92Yk53aU1Ea3VBNUxxT3ppbTNF
+            eitjWmowVUx2U052VTJFMnkxLzlSV0UKvvHCYhepRIu/JGNmlY9DButugFloQimJ
+            hXajEqyIIIBz9Pa302lapFFMle7X1xnSyY4FRLlFwiszJOv5zsh52A==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1urzhxxn7crgc7u9rc43dww2tfs6mggu6lukskzudrrspx4xz4sussrp3ls
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArM3JnUnVsb3ZyZTBnaE9n
-            aEF6Y09WY2VqWFJ1ekliQ3hXcFg5Z1pmT0dnCkNsVG1pTkYrNmFpY0NTTEFrUmJw
-            bDNYMC9Uc0I5aU5jb1d6bWNQbG5lNVkKLS0tIGhEQ0tLRDNWZDZRdFUvdmxXRTdQ
-            ZmE1RVo1SWF2SHdxa1RrU09yc0JWT0UKsdhHbKxHOsd0HAKNCbVoMUB7eNpw6ttM
-            rWpYigoohv1yBB4XF+aTiHiwBaiPelseAq6tZfBBYQfg7jdn8lBl+g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNZitLMzFFTkxVZDZZODJ0
+            cnVCcTE4QXZvYnBWcjJTS2IzOGc4VHN4RmswCmJZYlhtNm8wTzVoVmRRa2cyYlNh
+            NkVHZDdWTHBIN1ZhNUR2Q0pSekZycDAKLS0tIG9uYjZtWEJkVFhtWUdtVHZsdmtL
+            Z2VxMWp3UWdqZEkyRTFUZW9JM01EZlEK2xwA2tbBZUuTR2oB3L+vWuIV0UcDCSDA
+            1reBLymah5q10qerDKPXsk84/mnTSrM7kkBuoo8uDrEXZK/L720AbQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-26T06:19:59Z"
-    mac: ENC[AES256_GCM,data:4FNAhC+pT3htIM8mdCGi7dk4L6d6iK05zxyPbc0v0vt6g9+RFeug3CQaFafSSHUdSI3rXR0ogjLlpOSHKPJrqlkqsnkYTNI7Zd3Q5VPSfGmHt7V9iODgcp3SidlSRlSnT2AhFV7Cik/1C+/9VUhyfTp9fkbzZKodbJgVme9EKAs=,iv:XsJ8lPk3HYG6tNyMCgezH9VV1ykawLw/63ILs+hwf3U=,tag:t9hNfGZXqQAXhz5SeMrMmQ==,type:str]
+    lastmodified: "2026-04-07T10:25:14Z"
+    mac: ENC[AES256_GCM,data:w/eaIq98+35Cs9GgukKRNpJDsrLHE4dk9TpN8rExUCBveDnpujV3ylLhImNFKkINvwaBU7AqTmVSPmfvYhkO0eoEH+OjI4+B3NMtfu9TCoGJs54hb1sZNZ5cUWFNStW3UtsZHztid6StQ0ZkJJAECUnhswA4d7qdjue/H7Gcg4s=,iv:/YjS4NzEkGbwVwjMQmiwS2s9KzYqns1a9F3FaJV2U0A=,tag:nZgNp8q6H07Jfjj/vzqJJQ==,type:str]
     pgp:
-        - created_at: "2026-03-17T07:15:27Z"
+        - created_at: "2026-04-07T10:25:14Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4D8VmEovl6hVQSAQdAo6BRX7vhjBjLDdzk/DfX5yScTXGPcNWq9Hz1B+VCXjEw
-            zEIAGVHW5yWLIl8N0LuzOfwi55bbMC4heFCw3495Wis4SPJjWPoLTVzrSLRimeqY
-            0lwB0Bqox4N6GWEZM6UeuwQcnzwlccVVyFS53h3VmLN0L0xPuKuiKCaZRYMq//xu
-            IvG9OMZL1hVUFTGD88Ozgn+cbWoCVNPn3tmRyTZPFfRPyEtQJlXYNyIhVC02hA==
-            =VN0n
+            hF4D8VmEovl6hVQSAQdAkfFx7hpQDE2SlLvWi/+VRGRej/LljVD+Z0DHWpxXwzYw
+            mKrl9aIlSv1Jarobl75DD9MZcUbsv0RZaQL+tkEf1n+TGPzNueXXBzRIGJeubwL4
+            0l4BPMXEyeWhm7enQpiRNyvX0r62PU+bnptbbpgcCjMKEWmoqs6rw97ztLvmnkQV
+            yJnJ8+/4Gp/DAStFmzzyju9keRDV2OJKQ68/Qw2rXjGi+cU+tB1pp3X+vIt+Rkgf
+            =yPbS
             -----END PGP MESSAGE-----
           fp: 4EDE451FC10722D0C6662C6FB99B8189C7C153F6
-        - created_at: "2026-03-17T07:15:27Z"
+        - created_at: "2026-04-07T10:25:14Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4DOXJtCWL9qAoSAQdAB8WMlobZAbZlCM3M1Q8QRlRkJ8Wc8D/RTC5qPdgvrDQw
-            ATPGWcXhy7+ERtgpuQykwfcFiJ0uNmhvDGckx9LI1OR5Jc9NUaYelV/BRHvGWJe4
-            0lwB2xEUkJiYQCI5BaiR56/Gw80+5gOrNuKPaesC2JhWYj/+MWlLyQ1ETh4k+rRB
-            s8OFNWXROzgw4qbieGBU886+0He28xdI+faPIUb9HcOOTnR+eRlMZyL1QHXhzA==
-            =ua6t
+            hF4DOXJtCWL9qAoSAQdA3IpCdWQfof0JctelqCDJoKLU8jy3RClzIK9QaFkrfwQw
+            qR+PnoXFci1k9cGJLJypk8R3sJCJkR2s0jcihdwftGg4y59HI4RmWhVIXw0SpaQs
+            0l4BRz7gR2Ebm/agum0KEbM+m1XY9du14dyjUcVPDSO8yXqgNHVLPqWhJOKYu5+T
+            ZiRgq96P05ihIPZmcP3pzZJ5WD3YCt2z0eNqoEz+ZchqoDYR88+I1eSyD5BFtsLl
+            =ViV3
             -----END PGP MESSAGE-----
           fp: 5AF06033B3CC0104450B4F25F438D971EBE848EE
     unencrypted_suffix: _unencrypted
-    version: 3.12.1
+    version: 3.12.2


### PR DESCRIPTION
Configure rust-web-server with license and public key, add cc-gateway module, improve openclaw packaging, and update flake.lock and secrets.

## Summary by Sourcery

Configure rust-web-server licensing, add and wire up a new cc-gateway service, harden openclaw-gateway dependency fetching, and refresh secrets and lockfile metadata.

New Features:
- Introduce a cc-gateway service module on oracle-amd-002 with SOPS-managed configuration and secrets.

Enhancements:
- Extend rust-web-server configuration to support license and public key files with stricter file permissions.
- Improve openclaw-gateway packaging on oracle-arm-002 by adding a resilient pnpm dependency fetch and preserving existing runtime patches.

Documentation:
- Add an implementation plan document outlining staged rollout and validation steps for cc-gateway and openclaw changes.

Chores:
- Rotate and add multiple SOPS-managed secrets and update sops metadata and flake lock state.