### PR TITLE
sunshine: KMS capture + NVENC on game; sg-office WAN ip

### DIFF
--- a/home-configurations/freeman.xiong.nix
+++ b/home-configurations/freeman.xiong.nix
@@ -117,6 +117,22 @@ in
     homeDirectory = osConfig.users.users."freeman.xiong".home;
     sessionPath = [ "$HOME/.local/bin" ];
   };
+
+  # Sunshine on Wayland+NVIDIA: zwlr_screencopy returns unusable dmabufs from
+  # the NVIDIA driver, so Moonlight clients see corrupted/garbled frames. KMS
+  # capture (Sunshine reads the GPU framebuffer directly via DRM, requires
+  # capSysAdmin which the system module already grants) bypasses Wayland for
+  # the capture path. encoder=nvenc tries the GPU encoder first; falls back
+  # to libx264 when libcuda.so.1 isn't reachable from the unit's lib path.
+  xdg.configFile."sunshine/sunshine.conf" = lib.mkIf hasGuiTag {
+    text = ''
+      address_family = ipv4
+      upnp = disabled
+      capture = kms
+      encoder = nvenc
+    '';
+  };
+
   programs = {
     git = {
       includes = [
@@ -208,7 +224,7 @@ in
           hostname = "172.22.240.99";
         };
         "sg-office" = {
-          hostname = "118.201.235.1";
+          hostname = "101.78.126.6";
         };
         "huawei-bj-001" = {
           hostname = "1.94.246.7";

--- a/nixos-configurations/game/default.nix
+++ b/nixos-configurations/game/default.nix
@@ -342,6 +342,11 @@
     };
   };
 
+  # Sunshine's NVENC encoder dlopen()s libcuda.so.1, which lives in
+  # /run/opengl-driver/lib on NixOS. Without this on the user-service env,
+  # CUDA fails to load and Sunshine silently falls back to libx264 (CPU).
+  systemd.user.services.sunshine.environment.LD_LIBRARY_PATH = "/run/opengl-driver/lib";
+
   programs = {
     ydotool = {
       enable = true;


### PR DESCRIPTION
## Summary

Two related Sunshine fixes for game + a stale ssh hostname:

1. **`xdg.configFile."sunshine/sunshine.conf"`** (gated on `hasGuiTag`) with `capture=kms` + `encoder=nvenc` + `address_family=ipv4` + `upnp=disabled`. On NVIDIA+Wayland (niri), `zwlr_screencopy` returns unusable dmabufs and Moonlight sees corrupted frames; KMS capture bypasses Wayland.
2. **`LD_LIBRARY_PATH=/run/opengl-driver/lib`** on `systemd.user.services.sunshine` (in `nixos-configurations/game/default.nix`) so `libcuda.so.1` loads — otherwise Sunshine silently uses `libx264` (CPU) instead of NVENC.
3. **ssh `sg-office` hostname** updated `118.201.235.1` → `101.78.126.6` (current sg-office WAN, reachable via router DMZ). Was stale — IP rotated.

## Verified
- KMS capture confirmed live on game: sunshine logs `Screencasting with KMS` + `Found monitor for DRM screencasting` after restart.
- Same pattern verified end-to-end on sg-office (separate PR in autolife/nixos).

## Test plan
- [ ] `sudo nixos-rebuild switch --flake ~/dotfiles` on game
- [ ] `~/.config/sunshine/sunshine.conf` is now a symlink to nix store
- [ ] `journalctl --user -u sunshine.service` shows `Found H.264 encoder: h264_nvenc`
- [ ] `ssh sg-office` from game resolves to `101.78.126.6` (after `home-manager` regenerates `~/.ssh/config`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Configure Sunshine to use KMS capture with NVENC on the game host and update the sg-office SSH host IP.

New Features:
- Add managed Sunshine configuration enabling KMS capture and NVENC encoding for Wayland/NVIDIA setups.

Bug Fixes:
- Ensure Sunshine can load CUDA libraries for NVENC by setting LD_LIBRARY_PATH in the user systemd service environment.
- Update the sg-office SSH host entry to the current WAN IP address.