### PR TITLE
chore: rebalance amd-001/amd-002 — IB Gateway sidecar + service moves

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1242,16 +1242,15 @@
         "uv2nix": "uv2nix_3"
       },
       "locked": {
-        "lastModified": 1781018891,
+        "lastModified": 1781020752,
         "narHash": "sha256-pUOSybm7UcB4beDTJ0Ja5988wYf80hqfADmozKiIzJI=",
         "owner": "xiongchenyu6",
         "repo": "nur-packages",
-        "rev": "44559524d97058deaaa31ab1d759d842e9dd75f9",
+        "rev": "8615183a36ff7a2f8dfc8531576da3c3dc6ca996",
         "type": "github"
       },
       "original": {
         "owner": "xiongchenyu6",
-        "ref": "feat/nautilus-equity-trend-ib",
         "repo": "nur-packages",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1780798214,
-        "narHash": "sha256-FSgjp5mA36AWGQye7LO0COizgFI3C7YmxMhVhP6/CNE=",
+        "lastModified": 1780881774,
+        "narHash": "sha256-rerEuAetLDa/0drxCKlG3FOm+IaERC85bjePsEAgNqI=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "d03f85ef2700285c0dc4044d265236e881b4a024",
+        "rev": "d2516f1045bcce250f7116232899b33252c2866a",
         "type": "github"
       },
       "original": {
@@ -488,11 +488,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1780694373,
-        "narHash": "sha256-wuj6QmOlLsGjBOut+Ki/hiOT/H5ONzBePqOkOolsNfo=",
+        "lastModified": 1780881952,
+        "narHash": "sha256-GODp7ngnwtErDGnF082Y+iGhgVuHMsSfTjOSrBfDJO8=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "8f7043c852210cd0875a1bbe9ca872c90ab5ac74",
+        "rev": "b0a0cf623fbc48e572bff38b6302a1e172aaf011",
         "type": "github"
       },
       "original": {
@@ -691,11 +691,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {
@@ -715,11 +715,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780810304,
-        "narHash": "sha256-IIkoJCmnl/bNeLgRbghw+wZPt9K0IWKkDoe0StL9Vhk=",
+        "lastModified": 1780881487,
+        "narHash": "sha256-PNMUhO9H2uiHnzFnVxzsX8doz2jjpYLO543RBLYLrT8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6c4808b5362386d3c395852f5372d0ab9b7fd209",
+        "rev": "38c9b0a89e4e544acc282c837bedc64f6abde1e8",
         "type": "github"
       },
       "original": {
@@ -1242,11 +1242,11 @@
         "uv2nix": "uv2nix_3"
       },
       "locked": {
-        "lastModified": 1780880871,
-        "narHash": "sha256-+juTaNTA+HuJTZWQju+/l1Fu+ZTj3lMolcU+NDxK4ew=",
+        "lastModified": 1780909690,
+        "narHash": "sha256-gZg3G6wnvow1/oUvgFTPdrv2bC1xV5euXM/YvATMg6w=",
         "owner": "xiongchenyu6",
         "repo": "nur-packages",
-        "rev": "4ed6ab4c5faa99f575bb84c06785a38b704a4bda",
+        "rev": "61f1965e0f21266c5dc87ce74add907089ce77ee",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -127,11 +127,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1780099841,
-        "narHash": "sha256-EVZd2RsbpreRUDSi9rBwPY+ZxoyMaiEBbZxxhljbaS4=",
+        "lastModified": 1780532242,
+        "narHash": "sha256-D+BsdpxmtUwtqGoY0IXPhHgTlmqgcZKCEo1oMyn7ep0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "0532eb17955225173906d671fb36306bdeb1e2dc",
+        "rev": "59a82a1222dd3b2080b5cc52a1a2e8d5f1b77f37",
         "type": "github"
       },
       "original": {
@@ -185,11 +185,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780290312,
-        "narHash": "sha256-eTAlX0CwgB84Ts3GaBd944A3DRXVMzgA0EqroZBISUo=",
+        "lastModified": 1780894562,
+        "narHash": "sha256-c3430xwxwhHipl3jigUGMMBfpaMylDqytW/kdmB3ZGs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "115e5211780054d8a890b41f0b7734cafad54dfe",
+        "rev": "24fed06cac83bcc44ac8efbb57cab1a82fa0bedc",
         "type": "github"
       },
       "original": {
@@ -368,11 +368,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780679734,
-        "narHash": "sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8=",
+        "lastModified": 1780943742,
+        "narHash": "sha256-01bTMR9ZPG+uxPaZBeOwagg5uxIaFYs2/3YIrOX+bCA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b2b7db486e06e098711dc291bb25db82850e1d16",
+        "rev": "df39142474950e42d5fc3bf2fef9d6c62abbe8d7",
         "type": "github"
       },
       "original": {
@@ -409,11 +409,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1780574905,
-        "narHash": "sha256-2YH74Fj5+/gc94qW7ZMN0YF3sMhf2BFB5NBaJgDsugo=",
+        "lastModified": 1780957691,
+        "narHash": "sha256-DElCq5E9lipzEW+K1chfiw9OQhkwjGsTNUQZheiWTio=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "e780b8e19d405b6906d759d270bbc125d221e81a",
+        "rev": "b9e331d75d4618c7073ea08ff30fddf9a7d2fb08",
         "type": "github"
       },
       "original": {
@@ -461,11 +461,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1780881774,
-        "narHash": "sha256-rerEuAetLDa/0drxCKlG3FOm+IaERC85bjePsEAgNqI=",
+        "lastModified": 1780967473,
+        "narHash": "sha256-nHZKs2DBPGXkMtlxCPhF8Eda/caxo6KWnPYg+/ZQWnc=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "d2516f1045bcce250f7116232899b33252c2866a",
+        "rev": "75f95cd0a6ffe17b9dadf478bd8e3ce4780d3181",
         "type": "github"
       },
       "original": {
@@ -488,11 +488,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1780881952,
-        "narHash": "sha256-GODp7ngnwtErDGnF082Y+iGhgVuHMsSfTjOSrBfDJO8=",
+        "lastModified": 1780944960,
+        "narHash": "sha256-/Tzx2TY0IVm/ptBvkKaLdOHADpM7xsUMfBKOpCibH1M=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "b0a0cf623fbc48e572bff38b6302a1e172aaf011",
+        "rev": "da6577a9bef8a4d7a9d7a2a0dc1e1089edb46bed",
         "type": "github"
       },
       "original": {
@@ -521,11 +521,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1780637332,
-        "narHash": "sha256-FeKyLRxLZu2EUnhifijZPDZRl0sVnPVHMtizAINNiN4=",
+        "lastModified": 1780938415,
+        "narHash": "sha256-QHyIMGSbCQW8d5qbOrMsm6gem10bO3Au2YLa3alJfHo=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "f717ae030fe56fc52522ebef69f17f3f09064ac4",
+        "rev": "6f1a2c5f0e8274223d4204b1f8d6f7f91538967e",
         "type": "github"
       },
       "original": {
@@ -715,11 +715,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780881487,
-        "narHash": "sha256-PNMUhO9H2uiHnzFnVxzsX8doz2jjpYLO543RBLYLrT8=",
+        "lastModified": 1780961908,
+        "narHash": "sha256-WpqoHY3A5GWFREOKyNazVSg6764Mavuv7JFmPlTco1Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "38c9b0a89e4e544acc282c837bedc64f6abde1e8",
+        "rev": "f1b647a8d731701a93f200ceb998bb75c5209cc2",
         "type": "github"
       },
       "original": {
@@ -993,11 +993,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780284119,
-        "narHash": "sha256-y2wR4Mk6D/N1ID4FZa2oUMStCUxyIoRzmgOOpLzoWmo=",
+        "lastModified": 1780802404,
+        "narHash": "sha256-bGtIUeLb0yChX4h6hB40OOCwcYhcpQZHXSDvZGdWgeM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "51390d0bfca0a68a8c337d215a4bbeddc2ca616e",
+        "rev": "8e596a8430f2ce54d55c742198187d6945a5501e",
         "type": "github"
       },
       "original": {
@@ -1242,15 +1242,16 @@
         "uv2nix": "uv2nix_3"
       },
       "locked": {
-        "lastModified": 1780909690,
-        "narHash": "sha256-gZg3G6wnvow1/oUvgFTPdrv2bC1xV5euXM/YvATMg6w=",
+        "lastModified": 1781018891,
+        "narHash": "sha256-pUOSybm7UcB4beDTJ0Ja5988wYf80hqfADmozKiIzJI=",
         "owner": "xiongchenyu6",
         "repo": "nur-packages",
-        "rev": "61f1965e0f21266c5dc87ce74add907089ce77ee",
+        "rev": "44559524d97058deaaa31ab1d759d842e9dd75f9",
         "type": "github"
       },
       "original": {
         "owner": "xiongchenyu6",
+        "ref": "feat/nautilus-equity-trend-ib",
         "repo": "nur-packages",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -75,8 +75,10 @@
       };
     };
     # Personal and project packages
+    # TEMP: pinned to the equity-trend feature branch for the amd-002 nautilus-equity-trend
+    # service. Revert to "...?lfs=1" (master) once feat/nautilus-equity-trend-ib is merged.
     xiongchenyu6 = {
-      url = "github:xiongchenyu6/nur-packages?lfs=1";
+      url = "github:xiongchenyu6/nur-packages?ref=feat/nautilus-equity-trend-ib&lfs=1";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";

--- a/flake.nix
+++ b/flake.nix
@@ -75,10 +75,8 @@
       };
     };
     # Personal and project packages
-    # TEMP: pinned to the equity-trend feature branch for the amd-002 nautilus-equity-trend
-    # service. Revert to "...?lfs=1" (master) once feat/nautilus-equity-trend-ib is merged.
     xiongchenyu6 = {
-      url = "github:xiongchenyu6/nur-packages?ref=feat/nautilus-equity-trend-ib&lfs=1";
+      url = "github:xiongchenyu6/nur-packages?lfs=1";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";

--- a/nixos-configurations/oracle-amd-001/default.nix
+++ b/nixos-configurations/oracle-amd-001/default.nix
@@ -9,9 +9,7 @@
 }:
 {
   imports = with inputs; [
-    xiongchenyu6.nixosModules.casdoor
-    xiongchenyu6.nixosModules.openagent
-    xiongchenyu6.nixosModules.sub2api
+    hermes-agent.nixosModules.default
     disko.nixosModules.disko
     (modulesPath + "/installer/scan/not-detected.nix")
     (modulesPath + "/profiles/qemu-guest.nix")
@@ -20,62 +18,108 @@
     ezModules.core
     ezModules.server
     ezModules.acme
-    ezModules.datadog-agent
     ezModules.sing-box
     srvos.nixosModules.server
     ezModules.mixins-nginx
     srvos.nixosModules.mixins-trusted-nix-caches
     srvos.nixosModules.mixins-nix-experimental
     srvos.nixosModules.mixins-tracing
+    xiongchenyu6.nixosModules.cc-gateway
     ./hardware-configuration.nix
   ];
 
   sops.secrets."cloudflared/tunnel-credentials" = { };
-  sops.secrets."casdoor/db_password" = { };
-  sops.secrets."casibase/client_id" = { };
-  sops.secrets."casibase/client_secret" = { };
-  sops.secrets."sub2api/env" = {
-    owner = "sub2api";
-    group = "sub2api";
+
+  # hermes-agent moved here from amd-002 (frees amd-002 RAM + isolates the
+  # EOL-nodejs build to this now-idle box). The XIAOMI_API_KEY / telegram-token
+  # SOPS keys already live in secrets/common.yaml, encrypted to all hosts
+  # incl. oracle-amd-001 — no re-encryption needed.
+  sops.templates."hermes-env".content = ''
+    XIAOMI_API_KEY=${config.sops.placeholder."api-keys/XIAOMI_API_KEY"}
+    TELEGRAM_BOT_TOKEN=${config.sops.placeholder."zeroclaw/telegram_bot_token"}
+  '';
+  sops.secrets."api-keys/XIAOMI_API_KEY".owner = "root";
+  sops.secrets."zeroclaw/telegram_bot_token".owner = "root";
+
+  # cc-gateway moved here from amd-002 (frees amd-002 RAM for the new IB Gateway
+  # container). Port 18443 is free on this box. The cc-gateway/* SOPS keys already
+  # live in secrets/common.yaml, encrypted to all hosts incl. oracle-amd-001 — no
+  # re-encryption needed.
+  sops.templates."cc-gateway-config" = {
+    content = ''
+      {
+        "server": {
+          "port": 18443
+        },
+        "upstream": {
+          "url": "https://api.anthropic.com"
+        },
+        "identity": {
+          "device_id": "${config.sops.placeholder."cc-gateway/device_id"}",
+          "email": "${config.sops.placeholder."cc-gateway/email"}"
+        },
+        "oauth": {
+          "refresh_token": "${config.sops.placeholder."cc-gateway/refresh_token"}"
+        },
+        "auth": {
+          "tokens": ${config.sops.placeholder."cc-gateway/client_tokens"}
+        },
+        "env": {
+          "platform": "linux",
+          "platform_raw": "linux",
+          "arch": "x86_64",
+          "node_version": "v22.0.0",
+          "terminal": "xterm-256color",
+          "package_managers": "npm",
+          "runtimes": "node",
+          "is_running_with_bun": false,
+          "is_ci": false,
+          "is_claude_ai_auth": true,
+          "version": "2.1.81",
+          "version_base": "2.1.81",
+          "build_time": "2026-03-20T21:26:18Z",
+          "deployment_environment": "nixos",
+          "vcs": "git"
+        },
+        "prompt_env": {
+          "platform": "linux",
+          "shell": "bash",
+          "os_version": "NixOS",
+          "working_dir": "/var/lib/cc-gateway"
+        },
+        "process": {
+          "constrained_memory": 34359738368,
+          "rss_range": [300000000, 500000000],
+          "heap_total_range": [40000000, 80000000],
+          "heap_used_range": [100000000, 200000000]
+        },
+        "logging": {
+          "level": "info",
+          "audit": true
+        }
+      }
+    '';
+    owner = "cc-gateway";
+    group = "cc-gateway";
+    mode = "0400";
   };
 
-  systemd.services.sub2api = {
-    after = [
-      "postgresql.service"
-      "redis-sub2api.service"
-    ];
-    requires = [
-      "postgresql.service"
-      "redis-sub2api.service"
-    ];
+  sops.secrets."cc-gateway/email".owner = "cc-gateway";
+  sops.secrets."cc-gateway/device_id".owner = "cc-gateway";
+  sops.secrets."cc-gateway/refresh_token".owner = "cc-gateway";
+  sops.secrets."cc-gateway/client_tokens".owner = "cc-gateway";
+
+  users.users.cc-gateway = {
+    isSystemUser = true;
+    group = "cc-gateway";
+    home = "/var/lib/cc-gateway";
+    createHome = true;
   };
-
-  # Inject openagent (formerly casibase) credentials into its config at runtime
-  systemd.services.openagent.serviceConfig.ExecStartPre = lib.mkAfter [
-    "+${pkgs.writeShellScript "openagent-inject-credentials" ''
-      cfg="/var/lib/openagent/conf/app.conf"
-      if [ -f "$cfg" ]; then
-        client_id=$(cat ${config.sops.secrets."casibase/client_id".path})
-        client_secret=$(cat ${config.sops.secrets."casibase/client_secret".path})
-        ${pkgs.gnused}/bin/sed -i "s|clientId = .*|clientId = $client_id|" "$cfg"
-        ${pkgs.gnused}/bin/sed -i "s|clientSecret = .*|clientSecret = $client_secret|" "$cfg"
-      fi
-    ''}"
-  ];
-
-  # Inject casdoor DB password into its config at runtime
-  systemd.services.casdoor.serviceConfig.ExecStartPre = lib.mkAfter [
-    "+${pkgs.writeShellScript "casdoor-inject-password" ''
-      cfg="/var/lib/casdoor/app.conf"
-      if [ -f "$cfg" ]; then
-        db_pass=$(cat ${config.sops.secrets."casdoor/db_password".path})
-        ${pkgs.gnused}/bin/sed -i "s|dataSourceName = .*|dataSourceName = \"user=casdoor password=$db_pass host=localhost port=5432 dbname=casdoor sslmode=disable\"|" "$cfg"
-      fi
-    ''}"
-  ];
+  users.groups.cc-gateway = { };
 
   environment = {
     systemPackages = [
+      inputs.xiongchenyu6.packages.x86_64-linux.cc-gateway
       pkgs.cloudflared
       pkgs.nix
     ];
@@ -104,154 +148,35 @@
           group = "nginx";
           reloadServices = [ "nginx.service" ];
         };
-        "starslab.qzz.io" = {
-          domain = "starslab.qzz.io";
-          extraDomainNames = [ "*.starslab.qzz.io" ];
-          group = "nginx";
-          reloadServices = [ "nginx.service" ];
-        };
       };
     };
   };
 
-  services = {
-    postgresql = {
-      enable = true;
-      package = pkgs.postgresql_18_jit;
-      authentication = ''
-        local all all trust
-        host  all  all 127.0.0.1/32 trust
-        host  all  all ::1/128 trust
-        host  all  all 0.0.0.0/0 scram-sha-256
-      '';
-      enableJIT = true;
-      enableTCPIP = true;
-      settings = {
-        log_connections = true;
-        log_statement = "all";
-        logging_collector = true;
-        log_disconnections = true;
-        log_destination = lib.mkForce "syslog";
+  services.hermes-agent = {
+    enable = true;
+    settings = {
+      model = {
+        default = "mimo-v2.5-pro";
+        provider = "xiaomi";
       };
-      ensureUsers = [
-        {
-          name = "casdoor";
-          ensureDBOwnership = true;
-        }
-        {
-          name = "casibase";
-          ensureDBOwnership = true;
-        }
-        {
-          name = "sub2api";
-          ensureDBOwnership = true;
-        }
-      ];
-      ensureDatabases = [
-        "casdoor"
-        "casibase"
-        "sub2api"
-      ];
+      # User-authored skills migrated from the old zeroclaw workspace. Hermes
+      # reads these alongside its built-in skill library; skill creation still
+      # writes to $HERMES_HOME/skills/. State dir /var/lib/hermes is rsynced
+      # from amd-002 at migration time (see deploy notes).
+      skills.external_dirs = [ "/var/lib/hermes/custom-skills" ];
     };
+    # Non-secret env vars (bot allowlist + provider endpoint). Secrets via environmentFiles.
+    environment = {
+      TELEGRAM_ALLOWED_USERS = "5368588092,5369058954";
+      XIAOMI_BASE_URL = "https://token-plan-cn.xiaomimimo.com/v1";
+    };
+    environmentFiles = [ config.sops.templates."hermes-env".path ];
+  };
 
-    casdoor = {
-      enable = true;
-      appName = "casdoor";
-      port = 8000;
-      runMode = "prod";
-      database = {
-        driver = "postgres";
-        host = "localhost";
-        port = 5432;
-        username = "casdoor";
-        name = "casdoor";
-      };
-      redis = {
-        enable = false;
-      };
-      autoStart = true;
-    };
-
-    openagent = {
-      enable = true;
-      port = 14000;
-      runMode = "prod";
-      database = {
-        driver = "postgres";
-        host = "localhost";
-        port = 5432;
-        username = "casibase";
-        name = "casibase";
-      };
-      casdoor = {
-        endpoint = "https://casdoor.panda.qzz.io";
-        clientId = "PLACEHOLDER_FROM_SOPS";
-        clientSecret = "PLACEHOLDER_FROM_SOPS";
-        organization = "built-in";
-        application = "app-casibase";
-      };
-      autoStart = true;
-    };
-
-    redis.servers.sub2api = {
-      enable = true;
-      port = 6379;
-    };
-
-    sub2api = {
-      enable = true;
-      port = 18088;
-      database = {
-        host = "/run/postgresql";
-        user = "sub2api";
-        name = "sub2api";
-      };
-      redis = {
-        host = "127.0.0.1";
-        port = 6379;
-      };
-      environmentFile = config.sops.secrets."sub2api/env".path;
-    };
-
-    nginx = {
-      virtualHosts = {
-        "casibase.panda.qzz.io" = {
-          forceSSL = true;
-          acmeRoot = null;
-          useACMEHost = "panda.qzz.io";
-          kTLS = true;
-          locations = {
-            "/" = {
-              proxyPass = "http://127.0.0.1:14000";
-              proxyWebsockets = true;
-            };
-          };
-        };
-        "casdoor.panda.qzz.io" = {
-          forceSSL = true;
-          acmeRoot = null;
-          useACMEHost = "panda.qzz.io";
-          kTLS = true;
-          locations = {
-            "/" = {
-              proxyPass = "http://127.0.0.1:8000";
-              proxyWebsockets = true;
-            };
-          };
-        };
-        "sub2api.starslab.qzz.io" = {
-          forceSSL = true;
-          acmeRoot = null;
-          useACMEHost = "starslab.qzz.io";
-          kTLS = true;
-          locations = {
-            "/" = {
-              proxyPass = "http://127.0.0.1:18088";
-              proxyWebsockets = true;
-            };
-          };
-        };
-      };
-    };
+  services.cc-gateway = {
+    enable = true;
+    port = 18443;
+    openFirewall = false;
+    configFile = config.sops.templates."cc-gateway-config".path;
   };
 }

--- a/nixos-configurations/oracle-amd-002/default.nix
+++ b/nixos-configurations/oracle-amd-002/default.nix
@@ -22,16 +22,14 @@ in
     ezModules.core
     ezModules.server
     ezModules.acme
-    ezModules.datadog-agent
     ezModules.sing-box
     srvos.nixosModules.server
     ezModules.mixins-nginx
     srvos.nixosModules.mixins-trusted-nix-caches
     srvos.nixosModules.mixins-nix-experimental
     srvos.nixosModules.mixins-tracing
-    xiongchenyu6.nixosModules.cc-gateway
-    hermes-agent.nixosModules.default
     ./hardware-configuration.nix
+    ./ib-gateway.nix
     {
       topology.self.interfaces.home = {
         type = "wireguard";
@@ -154,14 +152,6 @@ in
 
   sops.secrets."wireguard/tcloud" = { };
 
-  # Secret env file consumed by hermes-agent. Stored under the legacy
-  # `zeroclaw/telegram_bot_token` SOPS key — the YAML namespace in
-  # secrets/common.yaml is unchanged; only the nix references migrated.
-  sops.templates."hermes-env".content = ''
-    XIAOMI_API_KEY=${config.sops.placeholder."api-keys/XIAOMI_API_KEY"}
-    TELEGRAM_BOT_TOKEN=${config.sops.placeholder."zeroclaw/telegram_bot_token"}
-  '';
-
   sops.templates."s3fs-passwd" = {
     content = "${config.sops.placeholder."s3fs/access_key"}:${
       config.sops.placeholder."s3fs/secret_key"
@@ -174,9 +164,6 @@ in
   sops.secrets."s3fs/access_key" = { };
   sops.secrets."s3fs/secret_key" = { };
 
-  sops.secrets."api-keys/XIAOMI_API_KEY".owner = "root";
-  sops.secrets."zeroclaw/telegram_bot_token".owner = "root";
-
   services = {
     openssh = {
       enable = true;
@@ -188,110 +175,7 @@ in
     };
   };
 
-  sops.templates."cc-gateway-config" = {
-    content = ''
-      {
-        "server": {
-          "port": 18443
-        },
-        "upstream": {
-          "url": "https://api.anthropic.com"
-        },
-        "identity": {
-          "device_id": "${config.sops.placeholder."cc-gateway/device_id"}",
-          "email": "${config.sops.placeholder."cc-gateway/email"}"
-        },
-        "oauth": {
-          "refresh_token": "${config.sops.placeholder."cc-gateway/refresh_token"}"
-        },
-        "auth": {
-          "tokens": ${config.sops.placeholder."cc-gateway/client_tokens"}
-        },
-        "env": {
-          "platform": "linux",
-          "platform_raw": "linux",
-          "arch": "x86_64",
-          "node_version": "v22.0.0",
-          "terminal": "xterm-256color",
-          "package_managers": "npm",
-          "runtimes": "node",
-          "is_running_with_bun": false,
-          "is_ci": false,
-          "is_claude_ai_auth": true,
-          "version": "2.1.81",
-          "version_base": "2.1.81",
-          "build_time": "2026-03-20T21:26:18Z",
-          "deployment_environment": "nixos",
-          "vcs": "git"
-        },
-        "prompt_env": {
-          "platform": "linux",
-          "shell": "bash",
-          "os_version": "NixOS",
-          "working_dir": "/var/lib/cc-gateway"
-        },
-        "process": {
-          "constrained_memory": 34359738368,
-          "rss_range": [300000000, 500000000],
-          "heap_total_range": [40000000, 80000000],
-          "heap_used_range": [100000000, 200000000]
-        },
-        "logging": {
-          "level": "info",
-          "audit": true
-        }
-      }
-    '';
-    owner = "cc-gateway";
-    group = "cc-gateway";
-    mode = "0400";
-  };
-
-  sops.secrets."cc-gateway/email".owner = "cc-gateway";
-  sops.secrets."cc-gateway/device_id".owner = "cc-gateway";
-  sops.secrets."cc-gateway/refresh_token".owner = "cc-gateway";
-  sops.secrets."cc-gateway/client_tokens".owner = "cc-gateway";
-
-  users.users.cc-gateway = {
-    isSystemUser = true;
-    group = "cc-gateway";
-    home = "/var/lib/cc-gateway";
-    createHome = true;
-  };
-  users.groups.cc-gateway = { };
-
-  environment.systemPackages = with pkgs; [
-    inputs.xiongchenyu6.packages.x86_64-linux.cc-gateway
-    s3fs
-  ];
-
-  services.cc-gateway = {
-    enable = true;
-    port = 18443;
-    openFirewall = false;
-    configFile = config.sops.templates."cc-gateway-config".path;
-  };
-
-  services.hermes-agent = {
-    enable = true;
-    settings = {
-      model = {
-        default = "mimo-v2.5-pro";
-        provider = "xiaomi";
-      };
-      # User-authored skills migrated from the old zeroclaw workspace.
-      # External dirs are read-only to hermes; skill creation still writes
-      # to $HERMES_HOME/skills/. Hermes reads finnhub/flyclaw/self-improving/
-      # xiaohongshu-mcp from here alongside its built-in skill library.
-      skills.external_dirs = [ "/var/lib/hermes/custom-skills" ];
-    };
-    # Non-secret env vars (bot allowlist + provider endpoint). Secrets go via environmentFiles.
-    environment = {
-      TELEGRAM_ALLOWED_USERS = "5368588092,5369058954";
-      XIAOMI_BASE_URL = "https://token-plan-cn.xiaomimimo.com/v1";
-    };
-    environmentFiles = [ config.sops.templates."hermes-env".path ];
-  };
+  environment.systemPackages = with pkgs; [ s3fs ];
 
   # S3 FUSE mount for iDrive e2 docs bucket
   fileSystems."/mnt/s3/docs" = {

--- a/nixos-configurations/oracle-amd-002/default.nix
+++ b/nixos-configurations/oracle-amd-002/default.nix
@@ -28,8 +28,10 @@ in
     srvos.nixosModules.mixins-trusted-nix-caches
     srvos.nixosModules.mixins-nix-experimental
     srvos.nixosModules.mixins-tracing
+    xiongchenyu6.nixosModules.nautilus-equity-trend
     ./hardware-configuration.nix
     ./ib-gateway.nix
+    ./nautilus-equity.nix
     {
       topology.self.interfaces.home = {
         type = "wireguard";

--- a/nixos-configurations/oracle-amd-002/ib-gateway.nix
+++ b/nixos-configurations/oracle-amd-002/ib-gateway.nix
@@ -1,0 +1,74 @@
+{ config, ... }:
+# Headless Interactive Brokers Gateway (PAPER) for the quant US-equity engine.
+#
+# Why here: IB Gateway is an x86_64 GUI Java app with no real headless mode; it must
+# run under a virtual display with IBC driving the login. oracle-arm-002 (aarch64) can't
+# run it without emulation, so this x86_64 box is the sidecar. nautilus_equity on the mesh
+# (download_ib.py now, the live equity node later) connects over wg0 to 172.22.240.97:4002.
+#
+# Implementation: the gnzsnz/ib-gateway image bundles Gateway + IBC + Xvfb + VNC and tracks
+# IBKR's installer/version churn, which a hand-rolled buildFHSEnv derivation cannot. Still
+# fully declarative + sops; one block to remove.
+#
+# PREREQUISITE — disable 2FA on the paper login (IBKR portal → Settings → User Settings →
+# Secure Login System → exclude the paper user) or every daily restart blocks forever on a
+# phone prompt. Paper accounts permit this; live never would.
+let
+  # Bind the API to the WireGuard mesh address ONLY — never the public interface.
+  # wg0 is a trustedInterface on this host, so no firewall port needs opening.
+  wgAddr = "172.22.240.97";
+in
+{
+  # IB paper credentials. Add the values (never plaintext in the repo) with:
+  #   sops secrets/common.yaml
+  # then under the top level:
+  #   ib-gateway:
+  #     username: <paper user>
+  #     password: <paper password>
+  sops.secrets."ib-gateway/username" = { };
+  sops.secrets."ib-gateway/password" = { };
+
+  sops.templates."ib-gateway.env".content = ''
+    TWS_USERID=${config.sops.placeholder."ib-gateway/username"}
+    TWS_PASSWORD=${config.sops.placeholder."ib-gateway/password"}
+  '';
+
+  virtualisation.podman = {
+    enable = true;
+    autoPrune.enable = true;
+  };
+
+  virtualisation.oci-containers = {
+    backend = "podman";
+    containers.ib-gateway = {
+      # :stable tracks IBKR Gateway bumps. Pin a digest (image = "...@sha256:...")
+      # once a known-good build is soaked, so a silent upstream push can't change it.
+      image = "ghcr.io/gnzsnz/ib-gateway:stable";
+      environmentFiles = [ config.sops.templates."ib-gateway.env".path ];
+      environment = {
+        TRADING_MODE = "paper"; # SAFETY: paper only. live would be 4001 — intentionally unused.
+        READ_ONLY_API = "yes"; # data + reconcile only. Flip to "no" when paper-TRADING (Stage 4).
+        TWOFA_TIMEOUT_ACTION = "restart";
+        AUTO_RESTART_TIME = "11:59 PM"; # daily Gateway self-restart, outside US regular hours
+        TIME_ZONE = "America/New_York";
+      };
+      # Tune for the 956MB box: lower Gateway heap (768m->512m) so it stops swap-thrashing,
+      # and raise IBC's login-dialog timeout (60->180s) so the slow GUI renders before IBC
+      # gives up (the exit-1112 loop). Mounted over the image's files; the .vmoptions path
+      # pins Gateway version 10.45.1g — revisit on a major Gateway bump.
+      volumes = [
+        "${./ibgateway.vmoptions}:/home/ibgateway/Jts/ibgateway/10.45.1g/ibgateway.vmoptions:ro"
+        "${./ibc-config.ini.tmpl}:/home/ibgateway/ibc/config.ini.tmpl:ro"
+      ];
+      # Publish the paper API on the mesh IP only. The gnzsnz image binds Gateway's API to
+      # 127.0.0.1:4002 INSIDE the container (localhost-trusted) and runs a socat relay on
+      # container port 4004 -> 127.0.0.1:4002 so external clients appear as localhost. So we
+      # map host 4002 -> container 4004 (the relay), NOT container 4002 (loopback-only).
+      ports = [ "${wgAddr}:4002:4004" ];
+      # First-run debugging over VNC (mesh-only). Uncomment + set VNC_SERVER_PASSWORD in
+      # the sops env, watch the login succeed, then re-comment.
+      # ports = [ "${wgAddr}:4002:4002" "${wgAddr}:5900:5900" ];
+      extraOptions = [ "--pull=newer" ];
+    };
+  };
+}

--- a/nixos-configurations/oracle-amd-002/ib-gateway.nix
+++ b/nixos-configurations/oracle-amd-002/ib-gateway.nix
@@ -47,9 +47,14 @@ in
       environmentFiles = [ config.sops.templates."ib-gateway.env".path ];
       environment = {
         TRADING_MODE = "paper"; # SAFETY: paper only. live would be 4001 — intentionally unused.
-        READ_ONLY_API = "yes"; # data + reconcile only. Flip to "no" when paper-TRADING (Stage 4).
+        READ_ONLY_API = "no"; # paper-TRADING enabled (places simulated orders). Still PAPER (DU* acct).
         TWOFA_TIMEOUT_ACTION = "restart";
         AUTO_RESTART_TIME = "11:59 PM"; # daily Gateway self-restart, outside US regular hours
+        # On the daily restart, auto-take-over any lingering session instead of hanging on the
+        # "Existing session detected" dialog (which froze the API until a manual restart).
+        EXISTING_SESSION_DETECTED_ACTION = "primary";
+        # Auto-accept incoming API connections (the socat relay arrives as 127.0.0.1 = trusted).
+        TWS_ACCEPT_INCOMING = "accept";
         TIME_ZONE = "America/New_York";
       };
       # Tune for the 956MB box: lower Gateway heap (768m->512m) so it stops swap-thrashing,

--- a/nixos-configurations/oracle-amd-002/ibc-config.ini.tmpl
+++ b/nixos-configurations/oracle-amd-002/ibc-config.ini.tmpl
@@ -1,0 +1,960 @@
+# Note that in the comments in this file, TWS refers to both the Trader
+# Workstation and the IB Gateway, unless explicitly stated otherwise.
+#
+# When referred to below, the default value for a setting is the value
+# assumed if either the setting is included but no value is specified, or
+# the setting is not included at all.
+#
+# IBC may also be used to start the FIX CTCI Gateway. All settings
+# relating to this have names prefixed with FIX.
+#
+# The IB API Gateway and the FIX CTCI Gateway share the same code. Which
+# gateway actually runs is governed by an option on the initial gateway
+# login screen. The FIX setting described under IBC Startup
+# Settings below controls this.
+
+
+
+# =============================================================================
+# 1.   IBC Startup Settings
+# =============================================================================
+
+
+# IBC may be used to start the IB Gateway for the FIX CTCI. This
+# setting must be set to 'yes' if you want to run the FIX CTCI gateway. The
+# default is 'no'.
+
+FIX=no
+
+
+
+# =============================================================================
+# 2.   Authentication Settings
+# =============================================================================
+
+# TWS and the IB API gateway require a single username and password.
+# You may specify the username and password using the following settings:
+#
+#	IbLoginId
+#	IbPassword
+#
+# Alternatively, you can specify the username and password in the command
+# files used to start TWS or the Gateway, but this is not recommended for
+# security reasons.
+#
+# If you don't specify them, you will be prompted for them in the usual
+# login dialog when TWS starts (but whatever you have specified will be
+# included in the dialog automatically: for example you may specify the
+# username but not the password, and then you will be prompted for the
+# password via the login dialog). Note that if you specify either
+# the username or the password (or both) in the command file, then
+# IbLoginId and IbPassword settings defined in this file are ignored.
+#
+#
+# The FIX CTCI gateway requires one username and password for FIX order
+# routing, and optionally a separate username and password for market
+# data connections. You may specify the usernames and passwords using
+# the following settings:
+#
+#	FIXLoginId
+#	FIXPassword
+#	IbLoginId	(optional - for market data connections)
+#	IbPassword	(optional - for market data connections)
+#
+# Alternatively you can specify the FIX username and password in the
+# command file used to start the FIX CTCI Gateway, but this is not
+# recommended for security reasons.
+#
+# If you don't specify them, you will be prompted for them in the usual
+# login dialog when FIX CTCI gateway starts (but whatever you have
+# specified will be included in the dialog automatically: for example
+# you may specify the usernames but not the passwords, and then you will
+# be prompted for the passwords via the login dialog). Note that if you
+# specify either the FIX username or the FIX password (or both) on the
+# command line, then FIXLoginId and FIXPassword settings defined in this
+# file are ignored; he same applies to the market data username and
+# password.
+
+# IB API Authentication Settings
+# ------------------------------
+
+# Your TWS username:
+
+IbLoginId=${TWS_USERID}
+
+
+# Your TWS password:
+
+IbPassword=${TWS_PASSWORD}
+
+
+# FIX CTCI Authentication Settings
+# --------------------------------
+
+# Your FIX CTCI username:
+
+FIXLoginId=
+
+
+# Your FIX CTCI password:
+
+FIXPassword=
+
+
+# Second Factor Authentication Settings
+# -------------------------------------
+
+# If you have enabled more than one second factor authentication
+# device, TWS presents a list from which you must select the device
+# you want to use for this login. You can use this setting to
+# instruct IBC to select a particular item in the list on your
+# behalf. Note that you must spell this value exactly as it appears
+# in the list. If no value is set, you must manually select the
+# relevant list entry.
+
+SecondFactorDevice=${TWOFA_DEVICE}
+
+
+# If you use the IBKR Mobile app for second factor authentication,
+# and you fail to complete the process before the time limit imposed
+# by IBKR, this setting tells IBC whether to automatically restart
+# the login sequence, giving you another opportunity to complete
+# second factor authentication.
+#
+# Permitted values are 'yes' and 'no'.
+#
+# If this setting is not present or has no value, then the value
+# of the deprecated ExitAfterSecondFactorAuthenticationTimeout is
+# used instead. If this also has no value, then this setting defaults
+# to 'no'.
+#
+# NB: you must be using IBC v3.14.0 or later to use this setting:
+# earlier versions ignore it.
+
+ReloginAfterSecondFactorAuthenticationTimeout=${RELOGIN_AFTER_TWOFA_TIMEOUT}
+
+
+# This setting is only relevant if
+# ReloginAfterSecondFactorAuthenticationTimeout is set to 'yes',
+# or if ExitAfterSecondFactorAuthenticationTimeout is set to 'yes'.
+#
+# It controls how long (in seconds) IBC waits for login to complete
+# after the user acknowledges the second factor authentication
+# alert at the IBKR Mobile app. If login has not completed after
+# this time, IBC terminates.
+# The default value is 60.
+
+SecondFactorAuthenticationExitInterval=${TWOFA_EXIT_INTERVAL}
+
+
+# This setting specifies the timeout for second factor authentication
+# imposed by IB. The value is in seconds. You should not change this
+# setting unless you have reason to believe that IB has changed the
+# timeout. The default value is 180.
+
+SecondFactorAuthenticationTimeout=180
+
+
+# DEPRECATED SETTING
+# ------------------
+#
+# ExitAfterSecondFactorAuthenticationTimeout - THIS SETTING WILL BE
+# REMOVED IN A FUTURE RELEASE. For IBC version 3.14.0 and later, see
+# the notes for ReloginAfterSecondFactorAuthenticationTimeout above.
+#
+# For IBC versions earlier than 3.14.0: If you use the IBKR Mobile
+# app for second factor authentication, and you fail to complete the
+# process before the time limit imposed by IBKR, you can use this
+# setting to tell IBC to exit: arrangements can then be made to
+# automatically restart IBC in order to initiate the login sequence
+# afresh. Otherwise, manual intervention at TWS's
+# Second Factor Authentication dialog is needed to complete the
+# login.
+#
+# Permitted values are 'yes' and 'no'. The default is 'no'.
+#
+# Note that the scripts provided with the IBC zips for Windows and
+# Linux provide options to automatically restart in these
+# circumstances, but only if this setting is also set to 'yes'.
+
+ExitAfterSecondFactorAuthenticationTimeout=no
+
+
+# Trading Mode
+# ------------
+#
+# This indicates whether the live account or the paper trading
+# account corresponding to the supplied credentials is to be used.
+# The allowed values are 'live' (the default) and 'paper'.
+#
+# If this is set to 'live', then the credentials for the live
+# account must be supplied. If it is set to 'paper', then either
+# the live or the paper-trading credentials may be supplied.
+
+TradingMode=${TRADING_MODE}
+
+
+# Paper-trading Account Warning
+# -----------------------------
+#
+# Logging in to a paper-trading account results in TWS displaying
+# a dialog asking the user to confirm that they are aware that this
+# is not a brokerage account. Until this dialog has been accepted,
+# TWS will not allow API connections to succeed. Setting this
+# to 'yes' (the default) will cause IBC to automatically
+# confirm acceptance. Setting it to 'no' will leave the dialog
+# on display, and the user will have to deal with it manually.
+
+AcceptNonBrokerageAccountWarning=yes
+
+
+# Login Dialog Display Timeout
+#-----------------------------
+#
+# In some circumstances, starting TWS may result in failure to display
+# the login dialog. Restarting TWS may help to resolve this situation,
+# and IBC does this automatically.
+#
+# This setting controls how long (in seconds) IBC waits for the login
+# dialog to appear before restarting TWS.
+#
+# Note that in normal circumstances with a reasonably specified
+# computer the time to displaying the login dialog is typically less
+# than 20 seconds, and frequently much less. However many factors can
+# influence this, and it is unwise to set this value too low.
+#
+# The default value is 60.
+
+LoginDialogDisplayTimeout=180
+
+
+
+# =============================================================================
+# 3.   TWS Startup Settings
+# =============================================================================
+
+# Path to settings store
+# ----------------------
+#
+# Path to the directory where TWS should store its settings. This is
+# normally the folder in which TWS is installed. However you may set
+# it to some other location if you wish (for example if you want to
+# run multiple instances of TWS with different settings).
+#
+# It is recommended for clarity that you use an absolute path. The
+# effect of using a relative path is undefined.
+#
+# Linux and macOS users should use the appropriate path syntax.
+#
+# Note that, for Windows users, you MUST use double separator
+# characters to separate the elements of the folder path: for
+# example, IbDir=C:\\IBLiveSettings is valid, but
+# IbDir=C:\IBLiveSettings is NOT valid and will give unexpected
+# results. Linux and macOS users need not use double separators,
+# but they are acceptable.
+#
+# The default is the current working directory when IBC is
+# started, unless the TWS_SETTINGS_PATH setting in the relevant
+# start script is set.
+#
+# If both this setting and TWS_SETTINGS_PATH are set, then this
+# setting takes priority. Note that if they have different values,
+# auto-restart will not work.
+#
+# NB: this setting is now DEPRECATED. You should use the
+# TWS_SETTINGS_PATH setting in the relevant start script.
+
+IbDir=
+
+
+# Store settings on server
+# ------------------------
+#
+# TWS only: if you wish to store a copy of your TWS settings on
+# IB's servers as well as locally on your computer, set this to
+# 'yes': this enables you to run TWS on different computers
+# with the same configuration, market data lines, etc. If set
+# to 'no', running TWS on different computers will not share the
+# same settings. If no value is specified, TWS will obtain its
+# settings from the same place as the last time this user logged
+# in (whether manually or using IBC).
+#
+# Note that this setting does not apply to Gateway, which does not
+# provide this capability.
+
+StoreSettingsOnServer=
+
+
+# Minimize TWS on startup
+# -----------------------
+#
+# Set to 'yes' to minimize TWS when it starts:
+
+MinimizeMainWindow=no
+
+
+# Existing Session Detected Action
+# --------------------------------
+#
+# When a user logs on to an IBKR account for trading purposes by any means, the
+# IBKR account server checks to see whether the account is already logged in
+# elsewhere. If so, a dialog is displayed to both the users that enables them
+# to determine what happens next. The 'ExistingSessionDetectedAction' setting
+# instructs TWS how to proceed when it displays this dialog:
+#
+#   * If the new TWS session is set to 'secondary', the existing session continues
+#     and the new session terminates. Thus a secondary TWS session can never
+#     override any other session.
+#
+#   * If the existing TWS session is set to 'primary', the existing session
+#     continues and the new session terminates (even if the new session is also
+#     set to primary). Thus a primary TWS session can never be overridden by
+#     any new session).
+#
+#   * If both the existing and the new TWS sessions are set to 'primaryoverride',
+#     the existing session terminates and the new session proceeds.
+#
+#   * If the existing TWS session is set to 'manual', the user must handle the
+#     dialog.
+#
+# The difference between 'primary' and 'primaryoverride' is that a
+# 'primaryoverride' session can be overriden over by a new 'primary' session,
+# but a 'primary' session cannot be overriden by any other session.
+#
+# When set to 'primary', if another TWS session is started and manually told to
+# end the 'primary' session, the 'primary' session is automatically reconnected.
+#
+# The default is 'manual'.
+
+ExistingSessionDetectedAction=${EXISTING_SESSION_DETECTED_ACTION}
+
+
+# Override TWS API Port Number
+# ----------------------------
+#
+# If OverrideTwsApiPort is set to an integer, IBC changes the
+# 'Socket port' in TWS's API configuration to that number shortly
+# after startup (but note that for the FIX Gateway, this setting is
+# actually stored in jts.ini rather than the Gateway's settings
+# file). Leaving the setting blank will make no change to
+# the current setting. This setting is only intended for use in
+# certain specialized situations where the port number needs to
+# be set dynamically at run-time, and for the FIX Gateway: most
+# non-FIX users will never need it, so don't use it unless you know
+# you need it.
+
+OverrideTwsApiPort=
+
+
+# Override TWS Master Client ID
+# -----------------------------
+#
+# If OverrideTwsMasterClientID is set to an integer, IBC changes the
+# 'Master Client ID' value in TWS's API configuration to that
+# value shortly after startup. Leaving the setting blank will make
+# no change to the current setting. This setting is only intended
+# for use in certain specialized situations where the value needs to
+# be set dynamically at run-time: most users will never need it,
+# so don't use it unless you know you need it.
+
+OverrideTwsMasterClientID=${TWS_MASTER_CLIENT_ID}
+
+
+# Read-only Login
+# ---------------
+#
+# If ReadOnlyLogin is set to 'yes', and the user is enrolled in IB's
+# account security programme, the user will not be asked to perform
+# the second factor authentication action, and login to TWS will
+# occur automatically in read-only mode: in this mode, placing or
+# managing orders is not allowed.
+#
+# If set to 'no', and the user is enrolled in IB's account security
+# programme, the second factor authentication process is handled
+# according to the Second Factor Authentication Settings described
+# elsewhere in this file.
+#
+# If the user is not enrolled in IB's account security programme,
+# this setting is ignored. The default is 'no'.
+
+ReadOnlyLogin=no
+
+
+# Read-only API
+# -------------
+#
+# If ReadOnlyApi is set to 'yes', API programs cannot submit, modify
+# or cancel orders. If set to 'no', API programs can do these things.
+# If not set, the existing TWS/Gateway configuration is unchanged.
+# NB: this setting is really only supplied for the benefit of new TWS
+# or Gateway instances that are being automatically installed and
+# started without user intervention (eg Docker containers). Where
+# a user is involved, they should use the Global Configuration to
+# set the relevant checkbox (this only needs to be done once) and
+# not provide a value for this setting.
+
+ReadOnlyApi=${READ_ONLY_API}
+
+
+# API Precautions
+# ---------------
+#
+# These settings relate to the corresponding 'Precautions' checkboxes in the
+# API section of the Global Configuration dialog.
+#
+# For all of these, the accepted values are:
+# - 'yes' sets the checkbox
+# - 'no' clears the checkbox
+# - if not set, the existing TWS/Gateway configuration is unchanged
+#
+# NB: thess settings are really only supplied for the benefit of new TWS
+# or Gateway instances that are being automatically installed and
+# started without user intervention, or where user settings are not preserved
+# between sessions (eg some Docker containers). Where a user is involved, they
+# should use the Global Configuration to set the relevant checkboxes and not
+# provide values for these settings.
+
+BypassOrderPrecautions=${BYPASS_WARNING}
+
+BypassBondWarning=${BYPASS_WARNING}
+
+BypassNegativeYieldToWorstConfirmation=${BYPASS_WARNING}
+
+BypassCalledBondWarning=${BYPASS_WARNING}
+
+BypassSameActionPairTradeWarning=${BYPASS_WARNING}
+
+BypassPriceBasedVolatilityRiskWarning=${BYPASS_WARNING}
+
+BypassUSStocksMarketDataInSharesWarning=${BYPASS_WARNING}
+
+BypassRedirectOrderWarning=${BYPASS_WARNING}
+
+BypassNoOverfillProtectionPrecaution=${BYPASS_WARNING}
+
+
+
+# Market data size for US stocks - lots or shares
+# -----------------------------------------------
+#
+# Since IB introduced the option of market data for US stocks showing
+# bid, ask and last sizes in shares rather than lots, TWS and Gateway
+# display a dialog immediately after login notifying the user about
+# this and requiring user input before allowing market data to be
+# accessed. The user can request that the dialog not be shown again.
+#
+# It is recommended that the user should handle this dialog manually
+# rather than using these settings, which are provided for situations
+# where the user interface is not easily accessible, or where user
+# settings are not preserved between sessions (eg some Docker images).
+#
+# - If this setting is set to 'accept', the dialog will be handled
+#   automatically and the option to not show it again will be
+#   selected.
+#
+#   Note that in this case, the only way to allow the dialog to be
+#   displayed again is to manually enable the 'Bid, Ask and Last
+#   Size Display Update' message in the 'Messages' section of the TWS
+#   configuration dialog. So you should only use 'Accept' if you are
+#   sure you really don't want the dialog to be displayed again, or
+#   you have easy access to the user interface.
+#
+# - If set to 'defer', the dialog will be handled automatically (so
+#   that market data will start), but the option to not show it again
+#   will not be selected, and it will be shown again after the next
+#   login.
+#
+# - If set to 'ignore', the user has to deal with the dialog manually.
+#
+# The default value is 'ignore'.
+#
+# Note if set to 'accept' or 'defer', TWS also automatically sets
+# the API settings checkbox labelled 'Send market data in lots for
+# US stocks for dual-mode API clients'. IBC cannot prevent this.
+# However you can change this immmediately by setting
+# SendMarketDataInLotsForUSstocks (see below) to 'no' .
+
+AcceptBidAskLastSizeDisplayUpdateNotification=accept
+
+
+# This setting determines whether the API settings checkbox labelled
+# 'Send market data in lots for US stocks for dual-mode API clients'
+# is set or cleared. If set to 'yes', the checkbox is set. If set to
+# 'no' the checkbox is cleared. If defaulted, the checkbox is
+# unchanged.
+
+SendMarketDataInLotsForUSstocks=
+
+
+# Trusted API Client IPs
+# ----------------------
+#
+# NB: THIS SETTING IS ONLY RELEVANT FOR THE GATEWAY, AND ONLY WHEN FIX=yes.
+# In all other cases it is ignored.
+#
+# This is a list of IP addresses separated by commas. API clients with IP
+# addresses in this list are able to connect to the API without Gateway
+# generating the 'Incoming connection' popup.
+#
+# Note that 127.0.0.1 is always permitted to connect, so do not include it
+# in this setting.
+
+TrustedTwsApiClientIPs=
+
+
+# Reset Order ID Sequence
+# -----------------------
+#
+# The setting resets the order id sequence for orders submitted via the API, so
+# that the next invocation of the `NextValidId` API callback will return the
+# value 1. The reset occurs when TWS starts.
+#
+# Note that order ids are reset for all API clients, except those that have
+# outstanding (ie incomplete) orders: their order id sequence carries on as
+# before.
+#
+# Valid values are 'yes', 'true', 'false' and 'no'. The default is 'no'.
+
+ResetOrderIdsAtStart=
+
+
+# This setting specifies IBC's action when TWS displays the dialog asking for
+# confirmation of a request to reset the API order id sequence.
+#
+# Note that the Gateway never displays this dialog, so this setting is ignored
+# for a Gateway session.
+#
+# Valid values consist of two strings separated by a solidus '/'. The first
+# value specifies the action to take when the order id reset request resulted
+# from setting ResetOrderIdsAtStart=yes. The second specifies the action to
+# take when the order id reset request is a result of the user clicking the
+# 'Reset API order ID sequence' button in the API configuration. Each value
+# must be one of the following:
+#
+#    'confirm'
+#        order ids will be reset
+#
+#    'reject'
+#        order ids will not be reset
+#
+#    'ignore'
+#        IBC will ignore the dialog. The user must take action.
+#
+#    The default setting is ignore/ignore
+
+# Examples:
+#
+#    'confirm/reject' - confirm order id reset only if ResetOrderIdsAtStart=yes
+#                       and reject any user-initiated requests
+#
+#    'ignore/confirm' - user must decide what to do if ResetOrderIdsAtStart=yes
+#                       and confirm user-initiated requests
+#
+#    'reject/ignore'  - reject order id reset if  ResetOrderIdsAtStart=yes but
+#                       allow user to handle user-initiated requests
+
+ConfirmOrderIdReset=
+
+
+
+# =============================================================================
+# 4.   TWS Auto-Logoff, Auto-Restart and Cold Restart
+# =============================================================================
+#
+# TWS and Gateway insist on being restarted every day. Two alternative
+# automatic options are offered:
+#
+#    - Auto-Logoff: at a specified time, TWS shuts down tidily, without
+#      restarting. The user must make their own arrangements for restarting
+#      as required.
+#
+#    - Auto-Restart: at a specified time, TWS shuts down and then restarts
+#      without the user having to re-authenticate (in particulaar this avoids
+#      the need for second factor authentication after the initial login). Make
+#      sure to read the section on Auto-Restart limitations and Cold Restart
+#      below for important further information.
+#
+# The normal way to configure the time at which this happens is via the Lock
+# and Exit section of the Configuration dialog. Once this time has been
+# configured in this way, the setting persists until the user changes it again.
+#
+# However, there are situations where there is no user available to do this
+# configuration, or where there is no persistent storage (for example some
+# Docker images). In such cases, the auto-restart or auto-logoff time can be
+# set whenever IBC starts with the settings below.
+#
+# The value, if specified, must be a time in HH:MM AM/PM format, for example
+# 08:00 AM or 10:00 PM. Note that there must be a single space between the
+# two parts of this value; also that midnight is "12:00 AM" and midday is
+# "12:00 PM".
+#
+# If no value is specified for either setting, the currently configured
+# settings will apply. If a value is supplied for one setting, the other
+# setting is cleared. If values are supplied for both settings, only the
+# auto-restart time is set, and the auto-logoff time is cleared.
+#
+# Note that for a normal TWS/Gateway installation with persistent storage
+# (for example on a desktop computer) the value will be persisted as if the
+# user had set it via the configuration dialog.
+#
+# If you use the "RESTART" command via the IBC command server, and IBC is
+# running any version of the Gateway, note that this will set the Auto-Restart
+# time in Gateway's configuration dialog to the time at which the restart
+# actually happens (which may be up to a minute after the RESTART command is
+# issued). To prevent future auto-restarts at this time, you must make sure you
+# have set AutoLogoffTime or AutoRestartTime in this file to your desired value
+# before running IBC again.
+
+AutoLogoffTime=${AUTO_LOGOFF_TIME}
+
+AutoRestartTime=${AUTO_RESTART_TIME}
+
+
+# Auto-Restart limitations and Cold Restart
+# -----------------------------------------
+#
+# If you choose to use auto-restart, you should take note of the considerations
+# described at the link below. Note that where this information mentions
+# 'manual authentication', closing down and restarting IBC will do the job
+# (IBKR does not recognise the existence of IBC in its docuemntation). IBC
+# calls this procedure a Cold Restart.
+#
+#     https://www.ibkrguides.com/tws/usersguidebook/configuretws/auto_restart_info.htm?Highlight=auto-restart
+#
+# To assist in complying with the requirement to fully shut down TWS on
+# Sundays, IBC can be configured with a Cold Restart Time, which is a time
+# (specified in your local timeframe) that is after 01:00 US/Eastern. When
+# this time is reached on Sundays, IBC tidily closes TWS, and the script then
+# reloads IBC thus starting a new instance of TWS and initiating the usual full
+# logon. There is thus no need to make any other arrangements for closing and
+# restarting at the weekend. For a live account, the time chosen should be
+# convenient for you to handle 2FA alerts.
+#
+# When deciding what time to use for Cold Restart, bear in mind that the offset
+# between your timezone and US/Eastern may vary if transitions to and from
+# Daylight Saving Time occur on different days. For example in the UK, this
+# offset can vary between 4 hours and 6 hours, so in this case it would be
+# reasonable to set the Cold Restart time to, for example, 07:05, which is
+# always after 01:00 US/Eastern. However if you're not an early riser on
+# Sundays you might prefer a more sociable time such as 13:00.
+#
+# To initiate Cold Restart on Sundays, set this value to <hh:mm>, this being a
+# time in your local timezone that is after 01:00 US/Eastern:
+
+ColdRestartTime=${TWS_COLD_RESTART}
+
+
+
+# =============================================================================
+# 5.   TWS Tidy Closedown Time
+# =============================================================================
+#
+# Specifies a time at which TWS will close down tidily, with no restart.
+#
+# This is similar to AutoLogoffTime, but can include a day-of-the-week, whereas
+# AutoLogoffTime applies every day. So for example you could use ClosedownAt in
+# conjunction with AutoRestartTime to keep TWS running during the week, and to
+# shut down on Friday evenings after the markets close, without it running on
+# Saturday as well.
+#
+# To tell IBC to tidily close TWS at a specified time every day, set this value
+# to <hh:mm>, for example:
+# ClosedownAt=22:00
+#
+# To tell IBC to tidily close TWS at a specified day and time each week, set
+# this value to <dayOfWeek hh:mm>, for example:
+# ClosedownAt=Friday 22:00
+#
+# Note that the day of the week must be specified using your
+# default locale. Also note that Java will only accept
+# characters encoded to ISO 8859-1 (Latin-1). This means that
+# if the day name in your default locale uses any non-Latin-1
+# characters you need to encode them using Unicode escapes
+# (see http://java.sun.com/docs/books/jls/third_edition/html/lexical.html#3.3
+# for details). For example, to tidily close TWS at 12:00 on
+# Saturday where the default locale is Simplified Chinese,
+# use the following:
+# #ClosedownAt=\u661F\u671F\u516D 12:00
+
+ClosedownAt=
+
+
+
+# =============================================================================
+# 6.   Other TWS Settings
+# =============================================================================
+
+# Accept Incoming Connection
+# --------------------------
+#
+# If set to 'accept', IBC automatically accepts incoming
+# API connection dialogs. If set to 'reject', IBC
+# automatically rejects incoming API connection dialogs. If
+# set to 'manual', the user must decide whether to accept or reject
+# incoming API connection dialogs. The default is 'manual'.
+# NB: it is recommended to set this to 'reject', and to explicitly
+# configure which IP addresses can connect to the API in TWS's API
+# configuration page, as this is much more secure (in this case, no
+# incoming API connection dialogs will occur for those IP addresses).
+
+AcceptIncomingConnectionAction=${TWS_ACCEPT_INCOMING}
+
+
+# Allow Blind Trading
+# -------------------
+#
+# If you attempt to place an order for a contract for which
+# you have no market data subscription, TWS displays a dialog
+# to warn you against such blind trading.
+#
+#   yes   means the dialog is dismissed as though the user had
+# 	  clicked the 'Ok' button: this means that you accept
+# 	  the risk and want the order to be submitted.
+#
+#   no    means the dialog remains on display and must be
+#         handled by the user.
+
+AllowBlindTrading=${ALLOW_BLIND_TRADING}
+
+
+# Save Settings on a Schedule
+# ---------------------------
+#
+# You can tell TWS to automatically save its settings on a schedule
+# of your choosing. You can specify one or more specific times,
+# like this:
+#
+# SaveTwsSettingsAt=HH:MM [ HH:MM]...
+#
+# for example:
+# SaveTwsSettingsAt=08:00   12:30 17:30
+#
+# Or you can specify an interval at which settings are to be saved,
+# optionally starting at a specific time and continuing until another
+# time, like this:
+#
+#SaveTwsSettingsAt=Every n [{mins | hours}] [hh:mm] [hh:mm]
+#
+# where the first hh:mm is the start time and the second is the end
+# time. If you don't specify the end time, settings are saved regularly
+# from the start time till midnight. If you don't specify the start time.
+# settings are saved regularly all day, beginning at 00:00. Note that
+# settings will always be saved at the end time, even if that is not
+# exactly one interval later than the previous time. If neither 'mins'
+# nor 'hours' is specified, 'mins' is assumed. Examples:
+#
+# To save every 30 minutes all day starting at 00:00
+#SaveTwsSettingsAt=Every 30
+#SaveTwsSettingsAt=Every 30 mins
+#
+# To save every hour starting at 08:00 and ending at midnight
+#SaveTwsSettingsAt=Every 1 hours 08:00
+#SaveTwsSettingsAt=Every 1 hours 08:00 00:00
+#
+# To save every 90 minutes starting at 08:00 up to and including 17:43
+#SaveTwsSettingsAt=Every 90 08:00 17:43
+
+SaveTwsSettingsAt=${SAVE_TWS_SETTINGS}
+
+
+# Confirm Crypto Currency Orders Automatically
+# --------------------------------------------
+#
+# When you place an order for a cryptocurrency contract, a dialog is displayed
+# asking you to confirm that you want to place the order, and notifying you
+# that you are placing an order to trade cryptocurrency with Paxos, a New York
+# limited trust company, and not at Interactive Brokers.
+#
+#   transmit    means that the order will be placed automatically, and the
+#               dialog will then be closed
+#
+#   cancel      means that the order will not be placed, and the dialog will
+#               then be closed
+#
+#   manual      means that IBC will take no action and the user must deal
+#               with the dialog
+
+ConfirmCryptoCurrencyOrders=transmit
+
+
+
+# =============================================================================
+# 7.   Settings Specific to Indian Versions of TWS
+# =============================================================================
+
+# Indian versions of TWS may display a password expiry
+# notification dialog and a NSE Compliance dialog. These can be
+# dismissed by setting the following to yes. By default the
+# password expiry notice is not dismissed, but the NSE Compliance
+# notice is dismissed.
+
+# Warning: setting DismissPasswordExpiryWarning=yes will mean
+# you will not be notified when your password is about to expire.
+# You must then take other measures to ensure that your password
+# is changed within the expiry period, otherwise IBC will
+# not be able to login successfully.
+
+DismissPasswordExpiryWarning=no
+DismissNSEComplianceNotice=yes
+
+
+
+# =============================================================================
+# 8.   IBC Command Server Settings
+# =============================================================================
+
+# Do NOT CHANGE THE FOLLOWING SETTINGS unless you
+# intend to issue commands to IBC (for example
+# using telnet). Note that these settings have nothing to
+# do with running programs that use the TWS API.
+
+# Command Server Port Number
+# --------------------------
+#
+# The port number that IBC listens on for commands
+# such as "STOP". DO NOT set this to the port number
+# used for TWS API connections.
+#
+# The convention is to use 7462 for this port,
+# but it must be set to a different value from any other
+# IBC instance that might run at the same time.
+#
+# The default value is 0, which tells IBC not to start
+# the command server
+
+#CommandServerPort=7462
+CommandServerPort=0
+
+
+# Permitted Command Sources
+# -------------------------
+#
+# A comma separated list of IP addresses, or host names,
+# which are allowed addresses for sending commands to
+# IBC.  Commands can always be sent from the
+# same host as IBC is running on.
+
+ControlFrom=
+
+
+# Address for Receiving Commands
+# ------------------------------
+#
+# Specifies the IP address on which the Command Server
+# is to listen. For a multi-homed host, this can be used
+# to specify that connection requests are only to be
+# accepted on the specified address. The default is to
+# accept connection requests on all local addresses.
+
+BindAddress=
+
+
+# Command Prompt
+# --------------
+#
+# The specified string is output by the server when
+# the connection is first opened and after the completion
+# of each command. This can be useful if sending commands
+# using an interactive program such as telnet. The default
+# is that no prompt is output.
+# For example:
+#
+# CommandPrompt=>
+
+CommandPrompt=
+
+
+# Suppress Command Server Info Messages
+# -------------------------------------
+#
+# Some commands can return intermediate information about
+# their progress. This setting controls whether such
+# information is sent. The default is that such information
+# is not sent.
+
+SuppressInfoMessages=yes
+
+
+
+# =============================================================================
+# 9.   Diagnostic Settings
+# =============================================================================
+#
+# IBC can log information about the structure of windows
+# displayed by TWS. This information is useful when adding
+# new features to IBC or when behaviour is not as expected.
+#
+# The logged information shows the hierarchical organisation
+# of all the components of the window, and includes the
+# current values of text boxes and labels.
+#
+# Note that this structure logging has a small performance
+# impact, and depending on the settings can cause the logfile
+# size to be significantly increased. It is therefore
+# recommended that the LogStructureWhen setting be set to
+# 'never' (the default) unless there is a specific reason
+# that this information is needed.
+
+
+# Scope of Structure Logging
+# --------------------------
+#
+# The LogStructureScope setting indicates which windows are
+# eligible for structure logging:
+#
+#    - (default value) if set to 'known', only windows that
+#      IBC recognizes are eligible - these are windows that
+#      IBC has some interest in monitoring, usually to take
+#      some action on the user's behalf;
+#
+#    - if set to 'unknown', only windows that IBC does not
+#      recognize are eligible. Most windows displayed by
+#      TWS fall into this category;
+#
+#    - if set to 'untitled', only windows that IBC does not
+#      recognize and that have no title are eligible. These
+#      are usually message boxes or similar small windows,
+#
+#    - if set to 'all', then every window displayed by TWS
+#      is eligible.
+#
+
+LogStructureScope=known
+
+
+# When to Log Window Structure
+# ----------------------------
+#
+# The LogStructureWhen setting specifies the circumstances
+# when eligible TWS windows have their structure logged:
+#
+#     - if set to 'open' or 'yes' or 'true', IBC logs the
+#       structure of an eligible window the first time it
+#       is encountered;
+#
+#     - if set to 'openclose', the structure is logged every
+#       time an eligible window is opened or closed;
+#
+#    - if set to 'activate', the structure is logged every
+#      time an eligible window is made active;
+#
+#    - (default value) if set to 'never' or 'no' or 'false',
+#      structure information is never logged.
+#
+
+LogStructureWhen=never
+
+
+# DEPRECATED SETTING
+# ------------------
+#
+# LogComponents - THIS SETTING WILL BE REMOVED IN A FUTURE
+# RELEASE
+#
+# If LogComponents is set to any value, this is equivalent
+# to setting LogStructureWhen to that same value and
+# LogStructureScope to 'all': the actual values of those
+# settings are ignored. The default is that the values
+# of LogStructureScope and LogStructureWhen are honoured.
+
+#LogComponents=

--- a/nixos-configurations/oracle-amd-002/ibgateway.vmoptions
+++ b/nixos-configurations/oracle-amd-002/ibgateway.vmoptions
@@ -1,0 +1,32 @@
+#
+# This file contains VM parameters for IB Gateway 10.45.
+# Each parameter should be defined in a separate line and the
+# last line must be followed by a line feed. No leading or
+# trailing whitespaces are allowed in the same line, where a
+# parameter is defined.
+#
+# Lines starting with a '#' character are treated as comments
+# and ignored. Additionally, if a line contains a
+# '### keep on update' string, all parameters defined below will
+# be preserved on update.
+#
+
+# maximum Java heap size — lowered 768m -> 512m so Gateway fits the 956MB box
+# without swap-thrashing (the cause of the IBC LoginDialogDisplayTimeout=1112 loop).
+-Xmx512m
+
+# GC settings
+-XX:+UseG1GC
+-XX:MaxGCPauseMillis=200
+-XX:ParallelGCThreads=20
+-XX:ConcGCThreads=5
+-XX:InitiatingHeapOccupancyPercent=70
+
+-Dinstaller.uuid=2f5bc1ae-9f14-4656-a49f-c7f470abb084
+-DvmOptionsPath=/root/Jts/ibgateway/10.45.1g/ibgateway.vmoptions
+-Dsun.awt.nopixfmt=true
+-Dsun.java2d.noddraw=true
+-Dswing.boldMetal=false
+-Dsun.locale.formatasdefault=true
+
+### keep on update

--- a/nixos-configurations/oracle-amd-002/nautilus-equity.nix
+++ b/nixos-configurations/oracle-amd-002/nautilus-equity.nix
@@ -1,0 +1,38 @@
+{
+  inputs,
+  pkgs,
+  ...
+}:
+# US-equity HonestTrend live node (NautilusTrader via Interactive Brokers), PAPER only.
+# Counterpart to oracle-arm-002/nautilus.nix, but for the equity engine. Co-located with
+# the IB Gateway container (ib-gateway.nix) on this x86_64 box.
+#
+# No sops secrets here: this node connects to the LOCAL Gateway over the mesh and places
+# only simulated paper orders. The IB account id (DUQ654554) is not a secret, and there are
+# no exchange API keys (the Gateway holds the IBKR login; see ib-gateway.nix). The node's
+# own PAPER-ONLY guardrail refuses any non-DU* account / non-paper mode.
+#
+# CONNECTION: ib-gateway.nix publishes the API on the WireGuard mesh address only
+# (`${wgAddr}:4002:4004`), NOT on 127.0.0.1 — so the host-local client must dial the mesh
+# IP, not loopback. Hence host = "172.22.240.97" (overriding the module's 127.0.0.1 default).
+{
+  services.nautilus-equity-trend = {
+    enable = true;
+    # The nur overlay isn't applied globally on this host — reference the packages directly,
+    # exactly like oracle-arm-002/nautilus.nix does for the crypto services. The equity node
+    # additionally needs the IB adapter's `ibapi` module (nautilus-ibapi).
+    package = inputs.xiongchenyu6.packages.${pkgs.stdenv.hostPlatform.system}.nautilus-trader;
+    ibapiPackage = inputs.xiongchenyu6.packages.${pkgs.stdenv.hostPlatform.system}.nautilus-ibapi;
+
+    # The Gateway API is published on the mesh IP only (see header). 127.0.0.1 won't connect.
+    host = "172.22.240.97";
+    port = 4002; # Gateway paper (mapped to the container's socat relay).
+    clientId = 8; # dedicated live-node client id (5 = download_ib, 7 = order test).
+    account = "DUQ654554"; # PAPER account (DU*). The node refuses anything else.
+
+    # Recommended live config (STRATEGY_LEADERBOARD US Equity): 1h bars, EMA 50/100.
+    barSpec = "1-HOUR-LAST-EXTERNAL";
+    emaFast = 50;
+    emaSlow = 100;
+  };
+}

--- a/nixos-configurations/oracle-arm-002/default.nix
+++ b/nixos-configurations/oracle-arm-002/default.nix
@@ -26,6 +26,7 @@
     xiongchenyu6.nixosModules.freqtrade-ohlc-sync
     xiongchenyu6.nixosModules.nautilus-accumulator
     xiongchenyu6.nixosModules.nautilus-trend
+    xiongchenyu6.nixosModules.nautilus-signal
     ./disk-config.nix
     ./hardware-configuration.nix
     ./hashtopolis.nix

--- a/nixos-configurations/oracle-arm-002/nautilus.nix
+++ b/nixos-configurations/oracle-arm-002/nautilus.nix
@@ -22,6 +22,18 @@
     owner = "nautilus";
   };
 
+  # Telegram alert sink for the signal layer — same bot + chat the legacy
+  # event_dca/reactor daemons used, so alerts land in the same place.
+  sops.secrets."oracle-arm-002/telegram-bot-token" = { };
+  sops.secrets."oracle-arm-002/telegram-chat-id" = { };
+  sops.templates."nautilus-signal.env" = {
+    content = ''
+      TELEGRAM_BOT_TOKEN=${config.sops.placeholder."oracle-arm-002/telegram-bot-token"}
+      TELEGRAM_CHAT_ID=${config.sops.placeholder."oracle-arm-002/telegram-chat-id"}
+    '';
+    owner = "nautilus";
+  };
+
   services.nautilus-accumulator = {
     enable = true;
     # nur overlay isn't applied globally on this host — reference the package directly.
@@ -48,5 +60,16 @@
     entryLb = 168;
     exitLb = 72;
     environmentFile = config.sops.templates."nautilus-accumulator.env".path;
+  };
+
+  # Signal layer — spike (PUMP/DUMP) + accumulation-dip (FLASH/FAST) Telegram alerts.
+  # Data-only on Binance MAINNET public market data (real prices; no execution client,
+  # no money at risk). Replaces the retired standalone event_reactor / event_dca_bot daemons.
+  services.nautilus-signal = {
+    enable = true;
+    package = inputs.xiongchenyu6.packages.${pkgs.stdenv.hostPlatform.system}.nautilus-trader;
+    instruments = [ "BTCUSDT.BINANCE" "ETHUSDT.BINANCE" "SOLUSDT.BINANCE" ];
+    barSpec = "1-MINUTE-LAST-EXTERNAL";
+    environmentFile = config.sops.templates."nautilus-signal.env".path;
   };
 }

--- a/secrets/common.yaml
+++ b/secrets/common.yaml
@@ -114,6 +114,8 @@ oracle-arm-002:
     google-oauth-secret: ENC[AES256_GCM,data:qDiCtCr9ux3h0jPes8X+KpYNiGcaQaHwnhgVVow1zJlV7U8=,iv:1GcHpZTYVnDiA9uMcfXYnLtMRtSF6FY7HoeObD+w9nY=,tag:9siQEgtAeXBVK50ncNEt7w==,type:str]
     binance-api-key: ENC[AES256_GCM,data:8ttZtpyBPz/ytfSxXAtYlsHE2bl9HMGjZLSVrv16ab8GlryIuaun4LScNfrX4siIuNptLqif0f4Q9OxKf54DOg==,iv:4grkXhmDWV4hBTgoaDi05K/hfWZ0q/JCZZdFgCqDdXM=,tag:GXJSQ5zjdkbjwatQ7G4tOA==,type:str]
     binance-api-secret: ENC[AES256_GCM,data:dFgB7SjRPGMH8RNcMhTnURkcxWi9t2io07DfY8J2OhT5lr1WgLW0Ju0lKNEhyh0gFV3TyjUppkTQ6BxFq+xAseqIyw4jd3YNRNmD2kl28pYIMwTq7yVBA2JBncllZuWnc9+gblzCJgbzIjiLQX8gbXp/+qqVZ4g=,iv:F4vjQOPi7cTpONd3bqFuDne0nw9wwbQu1Z2cNnH2nKA=,tag:WPuyzQUS5IoxWikC6pdr3g==,type:str]
+    telegram-bot-token: ENC[AES256_GCM,data:EWf5ZzDW1IGULnlyaGJn8iXxYlUSlyKW23hOPBCf0FU3P/D4Q17qzIxTK33pCA==,iv:32fAV4dfRJr1cjpIciFoZukbBU894k0LYYR1fM92JN0=,tag:iLb9UVAZqEU+Ik/ArjAAcQ==,type:str]
+    telegram-chat-id: ENC[AES256_GCM,data:KLG0BvjAfYsjUA==,iv:TH1Lv822RbOlc2YyzBjPvAbhTboSy2HoPpBwbZ0APZ8=,tag:JqCOUs2lzZjgcmodbfMzjw==,type:str]
 sops:
     age:
         - enc: |
@@ -206,8 +208,8 @@ sops:
             SAyEG4QgAZKFs8tMMycB4BLeznz3cpsL5F99FToFZrypUlMr5jGlrw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1urzhxxn7crgc7u9rc43dww2tfs6mggu6lukskzudrrspx4xz4sussrp3ls
-    lastmodified: "2026-06-07T11:11:53Z"
-    mac: ENC[AES256_GCM,data:XK5w5KhB0er/opuyymyN4WTLOck8hWLRnpm/hBaZ6E0Q+cAPth6fF1RNOyYOQJz5FGMsbQYE67OvBdcAltU2pqZnLd41lLg3Z+LXsSwI8Bjdyn0ZoAPUT1T7TaFoaYbipvkTb+zZZvUKZ9V8y434kMiDyhN89tug7R//YZPU1w0=,iv:fGuYoYjZSFp3JaXRvE0BYLfKgafmYqdX8GPllrrbeQY=,tag:N/vjnimHKZDtsfSum2qgwQ==,type:str]
+    lastmodified: "2026-06-08T08:44:48Z"
+    mac: ENC[AES256_GCM,data:iASJPLNZykqXf20tMExlO8uOvvSkFf0CU2NMNW9lz83JdxLlXhypmIR3DcjsJQW3pd9rBSk0CitxXGOaAr8ARkhuGfBBKl2TuKVC8wDlX34adGf6Kx9cnor65iyrxUl21NMTkxQ5zOvDyEUmRuvlCEREmWj3c0gHTXtTdP+/UuI=,iv:DBEfB6kMziWbHD+TQDPJ1rp2A4aSU4Ad3s0ksvHpow8=,tag:QjTEeffVq8x8V4mJnwrehQ==,type:str]
     pgp:
         - created_at: "2026-05-04T03:06:19Z"
           enc: |-

--- a/secrets/common.yaml
+++ b/secrets/common.yaml
@@ -116,6 +116,9 @@ oracle-arm-002:
     binance-api-secret: ENC[AES256_GCM,data:dFgB7SjRPGMH8RNcMhTnURkcxWi9t2io07DfY8J2OhT5lr1WgLW0Ju0lKNEhyh0gFV3TyjUppkTQ6BxFq+xAseqIyw4jd3YNRNmD2kl28pYIMwTq7yVBA2JBncllZuWnc9+gblzCJgbzIjiLQX8gbXp/+qqVZ4g=,iv:F4vjQOPi7cTpONd3bqFuDne0nw9wwbQu1Z2cNnH2nKA=,tag:WPuyzQUS5IoxWikC6pdr3g==,type:str]
     telegram-bot-token: ENC[AES256_GCM,data:EWf5ZzDW1IGULnlyaGJn8iXxYlUSlyKW23hOPBCf0FU3P/D4Q17qzIxTK33pCA==,iv:32fAV4dfRJr1cjpIciFoZukbBU894k0LYYR1fM92JN0=,tag:iLb9UVAZqEU+Ik/ArjAAcQ==,type:str]
     telegram-chat-id: ENC[AES256_GCM,data:KLG0BvjAfYsjUA==,iv:TH1Lv822RbOlc2YyzBjPvAbhTboSy2HoPpBwbZ0APZ8=,tag:JqCOUs2lzZjgcmodbfMzjw==,type:str]
+ib-gateway:
+    username: ENC[AES256_GCM,data:n0M28Erja1AcpMQo,iv:M2qCqdlQ8z58jzu9TRIwNQVHSUV1VFeEeWfIyzABMAs=,tag:Sl5fNR+5LgnBr8yBLlbpbQ==,type:str]
+    password: ENC[AES256_GCM,data:tTKtBQlSVZftsA==,iv:0084vQqpYQPiM+LVkBJZyLB8lZYP+/+50qSkvKR2mkU=,tag:XUBqwmkQzsoOFNTRxQezvA==,type:str]
 sops:
     age:
         - enc: |
@@ -208,8 +211,8 @@ sops:
             SAyEG4QgAZKFs8tMMycB4BLeznz3cpsL5F99FToFZrypUlMr5jGlrw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1urzhxxn7crgc7u9rc43dww2tfs6mggu6lukskzudrrspx4xz4sussrp3ls
-    lastmodified: "2026-06-08T08:44:48Z"
-    mac: ENC[AES256_GCM,data:iASJPLNZykqXf20tMExlO8uOvvSkFf0CU2NMNW9lz83JdxLlXhypmIR3DcjsJQW3pd9rBSk0CitxXGOaAr8ARkhuGfBBKl2TuKVC8wDlX34adGf6Kx9cnor65iyrxUl21NMTkxQ5zOvDyEUmRuvlCEREmWj3c0gHTXtTdP+/UuI=,iv:DBEfB6kMziWbHD+TQDPJ1rp2A4aSU4Ad3s0ksvHpow8=,tag:QjTEeffVq8x8V4mJnwrehQ==,type:str]
+    lastmodified: "2026-06-09T13:27:58Z"
+    mac: ENC[AES256_GCM,data:CklR2ybJxrbmtcI47wxZ8p91Fc9oH9A5bA3DOjnRX6Qvr2P9S4VVe5MDuXOymCoqXqtg54KHpFVZqkFE7OrYxmgIfkXlJWKt2vvfk0euLRq6HxBCy7T2VHnCYse2czPrazCx3E/1Rqr19blc2cywboigrKNkMFrbuUmJNzhJWqM=,iv:0Y2IAhBtIraqTWPthM+KsMCacwMh8F+NXRCwtFsp4ZQ=,tag:Xy6gzuDlfcvsYGKqtAbzXg==,type:str]
     pgp:
         - created_at: "2026-05-04T03:06:19Z"
           enc: |-


### PR DESCRIPTION
Free RAM on the 956MB oracle-amd-002 to host a headless IB Gateway, by redistributing services across the two x86 boxes.

- **oracle-amd-002**: + `ib-gateway` (gnzsnz podman container, paper, API on wg `172.22.240.97:4002`, heap-tuned for 956MB, READ_ONLY_API=no for paper orders, EXISTING_SESSION_DETECTED_ACTION=primary). − hermes-agent, − datadog, − cc-gateway.
- **oracle-amd-001**: + hermes-agent (state migrated), + cc-gateway (moved from amd-002). − its old SSO/DB stack (casdoor/openagent/sub2api/redis/postgres, decommissioned), − datadog.

Both hosts eval green; both deployed and verified (amd-002 Gateway logs into IBKR paper DUQ654554 and fills orders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Redistribute services between oracle-amd-001 and oracle-amd-002 to free resources for a new IB Gateway sidecar, and add a nautilus signal alert pipeline on oracle-arm-002.

New Features:
- Add a headless IB Gateway podman container on oracle-amd-002, exposing a paper-trading API over the WireGuard mesh.
- Introduce nautilus-signal service on oracle-arm-002 to generate Binance market spike/dip alerts and send them to Telegram.

Enhancements:
- Move hermes-agent and cc-gateway services from oracle-amd-002 to oracle-amd-001, including associated SOPS secrets and system users.
- Decommission the legacy SSO/DB stack (casdoor, openagent, sub2api, postgres, redis) and related nginx vhosts from oracle-amd-001.
- Simplify oracle-amd-002 by dropping hermes-agent and cc-gateway configuration and associated secrets while keeping s3fs-only packages.
- Wire nautilus-signal module and Telegram credentials into oracle-arm-002 to reuse existing alert channels.