### PR TITLE
feat(amd-002 equity): SGD FX sizing + TimescaleDB persistence

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1242,11 +1242,11 @@
         "uv2nix": "uv2nix_3"
       },
       "locked": {
-        "lastModified": 1781020752,
-        "narHash": "sha256-pUOSybm7UcB4beDTJ0Ja5988wYf80hqfADmozKiIzJI=",
+        "lastModified": 1781023530,
+        "narHash": "sha256-eZTYj1qXaeymTZL2CUV1hDP37YtbI8U1JNnZtdT151M=",
         "owner": "xiongchenyu6",
         "repo": "nur-packages",
-        "rev": "8615183a36ff7a2f8dfc8531576da3c3dc6ca996",
+        "rev": "7ae1d708618d86397f1176bccc96fcf4f7bd34d1",
         "type": "github"
       },
       "original": {

--- a/nixos-configurations/oracle-amd-002/nautilus-equity.nix
+++ b/nixos-configurations/oracle-amd-002/nautilus-equity.nix
@@ -1,6 +1,7 @@
 {
   inputs,
   pkgs,
+  config,
   ...
 }:
 # US-equity HonestTrend live node (NautilusTrader via Interactive Brokers), PAPER only.
@@ -34,5 +35,23 @@
     barSpec = "1-HOUR-LAST-EXTERNAL";
     emaFast = 50;
     emaSlow = 100;
+
+    # The IB paper account base currency is SGD; the strategy sizes in USD (quote ccy),
+    # so convert (~0.74 USD per SGD). Without this it sizes off raw SGD and over-buys ~1.35x.
+    quotePerBaseFx = 0.74;
+
+    # Persist fills / closed positions to quant.nautilus_trades with asset_class='equity'.
+    environment = "testnet"; # NAUTILUS_ENV row tag — paper, non-real money.
+    environmentFile = config.sops.templates."nautilus-equity.env".path;
+  };
+
+  # TIMESCALE_URL for the trade ledger. quant-password is in common.yaml (encrypted to all
+  # hosts incl. amd-002). DB reached over the public Internet (db.panda.qzz.io), not the mesh.
+  sops.secrets."oracle-arm-002/quant-password" = { };
+  sops.templates."nautilus-equity.env" = {
+    content = ''
+      TIMESCALE_URL=postgres://quant:${config.sops.placeholder."oracle-arm-002/quant-password"}@db.panda.qzz.io:5432/api?sslmode=require
+    '';
+    owner = "nautilus";
   };
 }


### PR DESCRIPTION
Equity service sizes via quotePerBaseFx=0.74 (SGD base) + persists fills to quant.nautilus_trades via TIMESCALE_URL. flake.lock → nur master. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Configure the Nautilus equity service on oracle-amd-002 to account for SGD-based IB paper accounts and to persist trade fills to a TimescaleDB-backed trade ledger.

New Features:
- Add FX conversion configuration for SGD-based IB paper accounts when sizing USD-denominated equity trades.
- Persist equity fills and closed positions to the quant.nautilus_trades table via a TIMESCALE_URL environment configuration.

Enhancements:
- Define SOPS-managed secrets and environment template for Nautilus equity to inject TimescaleDB connection credentials.