### PR TITLE
chore: YubiKey OpenPGP-auth fixes + package updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -368,11 +368,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780943742,
-        "narHash": "sha256-01bTMR9ZPG+uxPaZBeOwagg5uxIaFYs2/3YIrOX+bCA=",
+        "lastModified": 1781129616,
+        "narHash": "sha256-Hl0Pz/QIKpePSU7SdK3BMe5VNmUhFvfWyg57GyawxzE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "df39142474950e42d5fc3bf2fef9d6c62abbe8d7",
+        "rev": "7dbd305f8b81050f223f00bcfbc8a6b74e048806",
         "type": "github"
       },
       "original": {
@@ -461,11 +461,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1780967473,
-        "narHash": "sha256-nHZKs2DBPGXkMtlxCPhF8Eda/caxo6KWnPYg+/ZQWnc=",
+        "lastModified": 1781140202,
+        "narHash": "sha256-hEIq258CpHUlpCjk4gDf8rTXxWaTEvH30oEWf5BrTFg=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "75f95cd0a6ffe17b9dadf478bd8e3ce4780d3181",
+        "rev": "bb53759b44fff85eea34903064abe14085e31317",
         "type": "github"
       },
       "original": {
@@ -488,11 +488,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1780944960,
-        "narHash": "sha256-/Tzx2TY0IVm/ptBvkKaLdOHADpM7xsUMfBKOpCibH1M=",
+        "lastModified": 1781038035,
+        "narHash": "sha256-X+uFuOQVWiouzl7eSV5JUgg4CAbv779QgEqOxIo6Gls=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "da6577a9bef8a4d7a9d7a2a0dc1e1089edb46bed",
+        "rev": "27982962e1dee4994b05d2b0b4a29f8de2529a55",
         "type": "github"
       },
       "original": {
@@ -607,11 +607,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1780310866,
-        "narHash": "sha256-fPBRVf6A5xlACYcOI59shGrjURuvwu0lRsDoSCEXt/I=",
+        "lastModified": 1781020964,
+        "narHash": "sha256-fS7xTi2j2iso5Hj7RNZLv/acDlCT+fgMVkVk40A7Uco=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "4ed851c979641e28597a05086332d75cdc9e395f",
+        "rev": "32c2cd9e46286c4eced3dc6b613c659126bf3cca",
         "type": "github"
       },
       "original": {
@@ -631,11 +631,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780765279,
-        "narHash": "sha256-md6QHmlIx40bQkun43M2eT8aav5GURGkXEMFwof6uZs=",
+        "lastModified": 1781098109,
+        "narHash": "sha256-XLMCx6WWMxNeM0SSLun6qVzpMQEGsXVPLU8a1ZNOUGU=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "3e6d8af994e2a2d31af7a91863d7c0d6e278d951",
+        "rev": "06873343409ec0200a48c85d0ef622c5dafc6aaa",
         "type": "github"
       },
       "original": {
@@ -715,11 +715,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780961908,
-        "narHash": "sha256-WpqoHY3A5GWFREOKyNazVSg6764Mavuv7JFmPlTco1Q=",
+        "lastModified": 1781150896,
+        "narHash": "sha256-kE7VvLJSjHmujYHXzCwsjhLW+P4fA9uU0uZ/mRBA6pg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f1b647a8d731701a93f200ceb998bb75c5209cc2",
+        "rev": "f8f50edd32293ce560faa40b06305c407c7aeb29",
         "type": "github"
       },
       "original": {
@@ -1080,11 +1080,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780545143,
-        "narHash": "sha256-y9aFcK8A3pctkW9G9LdppzPDsuBa3VzToADnacjir/A=",
+        "lastModified": 1781149687,
+        "narHash": "sha256-TanScAdzeSOcaVDN4V4rnTAlbuizMJlrVSSt9QkkPEA=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "bc0ca7b0f7c8ca9dc55166438fec4dc2dd74f8a4",
+        "rev": "7a66d11f03dd0588229af7a2b7018a435638dbf5",
         "type": "github"
       },
       "original": {
@@ -1242,11 +1242,11 @@
         "uv2nix": "uv2nix_3"
       },
       "locked": {
-        "lastModified": 1781023530,
-        "narHash": "sha256-eZTYj1qXaeymTZL2CUV1hDP37YtbI8U1JNnZtdT151M=",
+        "lastModified": 1781089277,
+        "narHash": "sha256-2YgNba97QFGelELH/6DkdkEtsayZWu/qUTm/NpB406g=",
         "owner": "xiongchenyu6",
         "repo": "nur-packages",
-        "rev": "7ae1d708618d86397f1176bccc96fcf4f7bd34d1",
+        "rev": "69e546149f7694e771a87dfb24134ff5bbaaafde",
         "type": "github"
       },
       "original": {

--- a/home-modules/cli-minimal.nix
+++ b/home-modules/cli-minimal.nix
@@ -209,6 +209,11 @@ in
         debug-level = "guru";
         log-file = "${config.home.homeDirectory}/.cache/gnupg/scdaemon.log";
         disable-ccid = true;
+        # Ignore the YubiKey PIV applet: gpg-agent otherwise auto-exposes the
+        # PIV 9A Ed25519 key over ssh and mis-encodes it (extra "Ed25519"
+        # curve field), which makes `ssh-add -L` fail with "invalid format".
+        # PIV is used directly via PC/SC by yubikey-crypto, not through scdaemon.
+        disable-application = "piv";
       };
       settings = {
         #keyserver = "hkps://keyserver.ubuntu.com";

--- a/home-modules/cli-server.nix
+++ b/home-modules/cli-server.nix
@@ -43,7 +43,8 @@
       pinentry.package = lib.mkDefault pkgs.pinentry-curses;
       enableSshSupport = true;
       sshKeys = [
-        "AB721FF9682FF07B88063C8FADEB89B859C7ACB1"
+        # YubiKey 32087478 OpenPGP Authentication key (keygrip)
+        "B68FCD72AC825180E7A69A6B0EC58850115D477E"
       ];
     };
   };

--- a/home-modules/gui/packages.nix
+++ b/home-modules/gui/packages.nix
@@ -56,6 +56,7 @@
         #v4l-utils
         dotnetCorePackages.sdk_8_0
         foundry
+        surfpool
         #record_screen
         apg
         #cava # audio visualizer
@@ -78,7 +79,7 @@
         procs
         ansible.out
         #qemu_kvm
-        #tpm2-tools
+        tpm2-tools
 
         # Cross-platform GUI apps (moved from Linux-only)
         keepassxc

--- a/home-modules/nixos-integration.nix
+++ b/home-modules/nixos-integration.nix
@@ -28,8 +28,9 @@
       v4l-utils
       pcsc-tools
       opensc
-      #sui
-      #zssh
+      bitcoin
+      sui
+      zssh
       record_screen
       # NetworkManager icon themes
       adwaita-icon-theme

--- a/nixos-configurations/oracle-arm-001/default.nix
+++ b/nixos-configurations/oracle-arm-001/default.nix
@@ -58,7 +58,7 @@
         openssh = {
           authorizedKeys.keys = [
             "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHI7o9MTDU81RCkqhKbnXHqJgdhal7adqUZDhKUAWxLc server-benjamintan"
-            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBQBxWE+A+8sO3oszjEiNSAjsoEUfltBJMqpRRO3ieUp cardno:32_087_478"
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILd3Wv8qfOx+hg+W/UMLArHvcBPBsPArOLamGARcZhbT cardno:32_087_478"
             "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDc+zRGg+dTUqo0XAbCGuyGZiRlZwY0MdjOCrpZpcNDBAIk940/epjlkKh/2WTz4hC4hkv4Ms30cCbcbAByATNDXyVKwUrxkAJnFsXU4dgrYZJ0WR+67AeKRb+41daEFhmSQQztji5KmyF0uCMkBGNPC3jF63ybPj0UAS59g761t25P21IeS6zOf5IjBDIxp7JvtgOnIoOT4qQDTJijdCqjJJ/vP8bWmvS8mCMS5HDAKHgfEk5a3eJGFR8AngFSp1DkH5Q9y+YkM42IVrU2UkT8a4Qi/J2BCUKUCDBSeEmmgoBd8NOpkwvjcm6HY92sVZLSjeIyuZrEy9luNMC38PZ1SLNhDDiESIYiFpBWDKrOH8TkZStwpwwIb6hcm/+Tew5kYQlyAeCu2ZT97TRp7978cJP9Isz2kSdLRiLp57T4462feYEOvEJrBxultnCdYk6h/B9KJ81XDGG6Zt9i4A6jUBA26a7TEA6RAr8YLRKzUtr5BHpkYcAfVYTysDklU00= summer@summers-MacBook-Pro.local"
           ];
         };

--- a/shares.toml
+++ b/shares.toml
@@ -55,6 +55,6 @@ gid = 1234
 gn = 'freeman'
 public-key = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIABVd0cIdwKzf4yLoRXQwjaaVYPFv8ZfYvTUMOMTFJ/p freeman@nixos'
 sn = 'xiong'
-yubikey = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILd3Wv8qfOx+hg+W/UMLArHvcBPBsPArOLamGARcZhbT cardno:32_087_47'
+yubikey = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILd3Wv8qfOx+hg+W/UMLArHvcBPBsPArOLamGARcZhbT cardno:32_087_478'
 tel = 123434132
 


### PR DESCRIPTION
scdaemon PIV exclusion (fixes the recurring ssh-agent 'agent refused operation'), OpenPGP auth keygrip switch + matching pubkeys (arm-001, shares.toml cardno typo), package additions, flake.lock bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust smartcard and SSH configuration for YubiKey OpenPGP auth while updating packages and flake inputs.

Bug Fixes:
- Exclude the YubiKey PIV applet from scdaemon to prevent malformed SSH keys causing ssh-agent operations to fail.
- Update the OpenPGP authentication keygrip and matching SSH public keys for the YubiKey-backed user and server configuration.
- Fix a truncated YubiKey card number reference in shares.toml.

Enhancements:
- Enable additional CLI and GUI packages including bitcoin, sui, zssh, surfpool, and tpm2-tools.
- Refresh flake.lock inputs to newer revisions.