### PR TITLE
chore: salvage useful remains of the stash backlog

### DIFF
--- a/home-modules/gui/linux.nix
+++ b/home-modules/gui/linux.nix
@@ -167,6 +167,22 @@
           collection-fontsrecommended
           collection-xetex
           latexmk
+          appendix
+          biber
+          awesomebox
+          fontawesome5
+          changepage
+          csquotes
+          algorithms
+          algorithmicx
+          algpseudocodex
+          titlesec
+          fontspec
+          microtype
+          amsmath
+          amssymb
+          mathtools
+          xfrac
           ;
       };
     };

--- a/home-modules/neovim.nix
+++ b/home-modules/neovim.nix
@@ -57,7 +57,7 @@ in
         opt.pumheight = 10
         opt.pumblend = 10
         opt.winblend = 0
-        opt.wrap = false
+        opt.wrap = true
         opt.linebreak = true
         opt.list = true
         opt.listchars = { tab = "» ", trail = "·", nbsp = "␣" };


### PR DESCRIPTION
Audited all 5 stashes vs main: later commits already superseded ~95% of stash@{1}. Surviving deltas: neovim wrap=true + the prepared texlive package list (inert, texlive disabled). Skips documented in the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable line wrapping in Neovim and extend the configured LaTeX/TeX Live package set for the Linux GUI environment.

Enhancements:
- Enable soft line wrapping in the Neovim configuration.
- Expand the TeX Live package list with additional LaTeX packages for document authoring.